### PR TITLE
Improve pruning test

### DIFF
--- a/NethermindNode.Core/Helpers/DockerCommands.cs
+++ b/NethermindNode.Core/Helpers/DockerCommands.cs
@@ -55,7 +55,7 @@ public static class DockerCommands
         return GetDockerDetails("sedge-execution-client", "{{ range .Mounts }}{{ if eq .Destination \\\"/nethermind/data\\\" }}{{ .Source }}{{ end }}{{ end }}", logger).Trim();
     }
 
-    public static IEnumerable<string> GetDockerLogs(string containerIdOrName, string logFilter = null, bool followLogs = false, CancellationToken? cancellationToken = null)
+    public static IEnumerable<string> GetDockerLogs(string containerIdOrName, string logFilter = null, bool followLogs = false, CancellationToken? cancellationToken = null, string additionaloptions = "")
     {
         string followFlag = followLogs ? "-f" : "";
         string grepCommand = string.IsNullOrEmpty(logFilter) ? "" : $"| grep \"{logFilter}\"";
@@ -63,7 +63,7 @@ public static class DockerCommands
         ProcessStartInfo psi = new ProcessStartInfo
         {
             FileName = "bash",
-            Arguments = $"-c \"docker logs {followFlag} {containerIdOrName} {grepCommand}\"",
+            Arguments = $"-c \"docker logs {followFlag} {additionaloptions} {containerIdOrName} {grepCommand}\"",
             RedirectStandardOutput = true,
             UseShellExecute = false,
             CreateNoWindow = true,

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -3,6 +3,7 @@ using NethermindNode.Core.Helpers;
 using NethermindNode.Tests.JsonRpc;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -43,8 +44,17 @@ namespace NethermindNode.Tests.Tests.Pruning
 
             Assert.IsTrue(result.Contains("Starting"), $"Result should contains \"Starting\" but it doesn't. Result content: {result}");
 
-            // Wait for 10 seconds for pruning to be properly started
-            Thread.Sleep(10000);
+            // Wait for maximum 60 seconds for pruning to be properly started
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            while (stateDirectories.Length != 2 && stopwatch.Elapsed < TimeSpan.FromSeconds(60))
+            {
+                System.Threading.Thread.Sleep(500);
+                stateDirectories = Directory.GetDirectories(statePath);
+            }
+
+            stopwatch.Stop();
 
             // Verify if second state dir is created
             stateDirectories = Directory.GetDirectories(statePath);

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -86,17 +86,19 @@ namespace NethermindNode.Tests.Tests.Pruning
 
                     foreach (var expectedLog in missingLogs)
                     {
-                        if (line.Contains(expectedLog))
+                        if (!line.Contains(expectedLog))
                         {
-                            Logger.Info($"Log found: \"{line}\" - Expected log: {expectedLog}");
-                            missingLogs.Remove(expectedLog);
+                            continue;
+                        }
 
-                            if (expectedLog == expectedLogs.Last())
-                            {
-                                // End becuase Pruning itself may work but for some reason some logs may not be found - so better this way than waiting for all
-                                cts.Cancel();
-                                break;
-                            }
+                        Logger.Info($"Log found: \"{line}\" - Expected log: {expectedLog}");
+                        missingLogs.Remove(expectedLog);
+
+                        if (expectedLog == expectedLogs.Last())
+                        {
+                            // End because Pruning itself may work but for some reason some logs may not be found - so better this way than waiting for all
+                            cts.Cancel();
+                            break;
                         }
                     }
                 }

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -59,8 +59,10 @@ namespace NethermindNode.Tests.Tests.Pruning
             // Verify if second state dir is created
             stateDirectories = Directory.GetDirectories(statePath);
             Assert.IsTrue(stateDirectories.Length == 2, "Pruning active - backup state directory should be created.");
-            Assert.IsTrue(stateDirectories[0].Split('/').Last() == "0", $"Invalid name of first state directory. Should be \"0\" but is {stateDirectories[0].Split('/').Last()}");
-            Assert.IsTrue(stateDirectories[1].Split('/').Last() == "1", $"Invalid name of second state directory. Should be \"1\" but is {stateDirectories[1].Split('/').Last()}");
+
+            var directoryNames = stateDirectories.Select(dir => dir.Split('/').Last()).ToList();
+            Assert.IsTrue(directoryNames.Contains("0"), $"Directory with name \"0\" not found. Found directories: {string.Join(", ", directoryNames)}");
+            Assert.IsTrue(directoryNames.Contains("1"), $"Directory with name \"1\" not found. Found directories: {string.Join(", ", directoryNames)}");
 
             // Verify Logs
             CancellationTokenSource cts = new CancellationTokenSource();

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -80,11 +80,11 @@ namespace NethermindNode.Tests.Tests.Pruning
 
             try
             {
-                foreach (var line in DockerCommands.GetDockerLogs("sedge-execution-client", "Full Pruning", true, cts.Token))
+                foreach (var line in DockerCommands.GetDockerLogs("sedge-execution-client", "Full Pruning", true, cts.Token, "--tail 0"))
                 {
                     Console.WriteLine(line); // For visibility during testing
 
-                    foreach (var expectedLog in expectedLogs)
+                    foreach (var expectedLog in missingLogs)
                     {
                         if (line.Contains(expectedLog))
                         {

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -80,7 +80,7 @@ namespace NethermindNode.Tests.Tests.Pruning
 
             try
             {
-                foreach (var line in DockerCommands.GetDockerLogs("sedge-execution-client", "Full Pruning", true, cts.Token, "--tail 0"))
+                foreach (var line in DockerCommands.GetDockerLogs("sedge-execution-client", "Full Pruning", true, cts.Token, "--since 2m"))
                 {
                     Console.WriteLine(line); // For visibility during testing
 
@@ -90,13 +90,13 @@ namespace NethermindNode.Tests.Tests.Pruning
                         {
                             Logger.Info($"Log found: \"{line}\" - Expected log: {expectedLog}");
                             missingLogs.Remove(expectedLog);
-                        }
-                    }
 
-                    if (missingLogs.Count == 0)
-                    {
-                        cts.Cancel();
-                        break;
+                            if (expectedLog == expectedLogs.Last())
+                            {
+                                cts.Cancel();
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -113,6 +113,9 @@ namespace NethermindNode.Tests.Tests.Pruning
             }
 
             Assert.That(missingLogs.Count, Is.EqualTo(0), $"Not all expected log substrings were found. Missing logs: {string.Join(", ", missingLogs)}");
+            
+            stateDirectories = Directory.GetDirectories(statePath);
+            Assert.That(stateDirectories.Length, Is.EqualTo(1), "After Pruning directories length should be back on 1.");
         }
     }    
 }

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -36,7 +36,6 @@ namespace NethermindNode.Tests.Tests.Pruning
             // Check if only one state 
             var stateDirectories = Directory.GetDirectories(statePath);
             Assert.That(stateDirectories.Length, Is.EqualTo(1), "Pruning not yet active so there should be only one state directory.");
-            Assert.That(stateDirectories[0].Split('/').Last(), Is.EqualTo("0"), "Invalid name of first state directory.");
 
             // Execute Prune Command
             var parameters = $"";
@@ -59,10 +58,6 @@ namespace NethermindNode.Tests.Tests.Pruning
             // Verify if second state dir is created
             stateDirectories = Directory.GetDirectories(statePath);
             Assert.IsTrue(stateDirectories.Length == 2, "Pruning active - backup state directory should be created.");
-
-            var directoryNames = stateDirectories.Select(dir => dir.Split('/').Last()).ToList();
-            Assert.IsTrue(directoryNames.Contains("0"), $"Directory with name \"0\" not found. Found directories: {string.Join(", ", directoryNames)}");
-            Assert.IsTrue(directoryNames.Contains("1"), $"Directory with name \"1\" not found. Found directories: {string.Join(", ", directoryNames)}");
 
             // Verify Logs
             CancellationTokenSource cts = new CancellationTokenSource();

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -112,7 +112,7 @@ namespace NethermindNode.Tests.Tests.Pruning
                 Logger.Warn($"Missing logs: {string.Join(", ", missingLogs)}");
             }
 
-            Assert.That(missingLogs.Count, Is.EqualTo(0), "Not all expected log substrings were found.");
+            Assert.That(missingLogs.Count, Is.EqualTo(0), $"Not all expected log substrings were found. Missing logs: {string.Join(", ", missingLogs)}");
         }
     }    
 }

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -59,8 +59,8 @@ namespace NethermindNode.Tests.Tests.Pruning
             // Verify if second state dir is created
             stateDirectories = Directory.GetDirectories(statePath);
             Assert.IsTrue(stateDirectories.Length == 2, "Pruning active - backup state directory should be created.");
-            Assert.IsTrue(stateDirectories[0].Split('/').Last() == "0", "Invalid name of first state directory.");
-            Assert.IsTrue(stateDirectories[1].Split('/').Last() == "1", "Invalid name of second state directory.");
+            Assert.IsTrue(stateDirectories[0].Split('/').Last() == "0", $"Invalid name of first state directory. Should be \"0\" but is {stateDirectories[0].Split('/').Last()}");
+            Assert.IsTrue(stateDirectories[1].Split('/').Last() == "1", $"Invalid name of second state directory. Should be \"1\" but is {stateDirectories[1].Split('/').Last()}");
 
             // Verify Logs
             CancellationTokenSource cts = new CancellationTokenSource();

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -91,18 +91,20 @@ namespace NethermindNode.Tests.Tests.Pruning
 
                     if (line.Contains(expectedLogs[expectedLogIndex]))
                     {
+                        Logger.Info($"Log found: \"{line}\" - Expected log: {expectedLogs[expectedLogIndex]}");
                         expectedLogIndex++;
                     }
 
                     if (expectedLogIndex >= expectedLogs.Length)
                     {
+                        cts.Cancel();
                         break;
                     }
                 }
             }
             catch (OperationCanceledException)
             {
-                Console.WriteLine("Operation was canceled."); 
+                Logger.Info("Operation was canceled."); 
             }
 
             Assert.That(expectedLogIndex, Is.EqualTo(expectedLogs.Length), "Not all expected log substrings were found in order.");

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -80,7 +80,7 @@ namespace NethermindNode.Tests.Tests.Pruning
 
             try
             {
-                foreach (var line in DockerCommands.GetDockerLogs("sedge-execution-client", "Full Pruning", true, cts.Token, "--since 2m"))
+                foreach (var line in DockerCommands.GetDockerLogs("sedge-execution-client", "Full Pruning", true, cts.Token, "--since 2m")) //since to ensure that we will get only recent logs but including all from beggining of test
                 {
                     Console.WriteLine(line); // For visibility during testing
 
@@ -93,6 +93,7 @@ namespace NethermindNode.Tests.Tests.Pruning
 
                             if (expectedLog == expectedLogs.Last())
                             {
+                                // End becuase Pruning itself may work but for some reason some logs may not be found - so better this way than waiting for all
                                 cts.Cancel();
                                 break;
                             }
@@ -107,11 +108,11 @@ namespace NethermindNode.Tests.Tests.Pruning
 
             if (missingLogs.Count > 0)
             {
+                // In case some of the logs were not displayed log Warning
                 Logger.Warn($"Missing logs: {string.Join(", ", missingLogs)}");
             }
 
-            Assert.That(missingLogs.Count, Is.EqualTo(0), "Not all expected log substrings were found in order.");
-
+            Assert.That(missingLogs.Count, Is.EqualTo(0), "Not all expected log substrings were found.");
         }
     }    
 }


### PR DESCRIPTION
This test is supposed to validate entire Pruning scenario using admin_prune json rpc command.

This is E2E test which needs to:
1. Sync node - Prerequisite to start pruning
2. Ensure state is in proper shape
3. Trigger pruning rpc admin_prune
4. Wait until additional state directory is created - Pruning is recreating entire state based on local directory so at the end there would be 2 identical state directories with same naming (but because of nature of pruning and the fact that it is still moving we can't exactly check if both are identical as for now)
5. Wait for specified logs afterwards to check if pruning process is progressing well
6. Do last asserts