### PR TITLE
Add possibility to specify container names by config

### DIFF
--- a/NethermindNode.Core/Helpers/ConfigurationHelper.cs
+++ b/NethermindNode.Core/Helpers/ConfigurationHelper.cs
@@ -18,10 +18,9 @@ namespace NethermindNode.Core.Helpers
 
         private ConfigurationHelper()
         {
-            string configPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"../../../nethermind-node-tests"));
 
             var builder = new ConfigurationBuilder()
-                .SetBasePath(configPath)
+                .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("config.json");
 
             Configuration = builder.Build();

--- a/NethermindNode.Core/Helpers/ConfigurationHelper.cs
+++ b/NethermindNode.Core/Helpers/ConfigurationHelper.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NethermindNode.Core.Helpers
+{
+    public sealed class ConfigurationHelper
+    {
+        private static readonly Lazy<ConfigurationHelper> lazyInstance =
+            new Lazy<ConfigurationHelper>(() => new ConfigurationHelper());
+
+        public static ConfigurationHelper Instance => lazyInstance.Value;
+
+        private IConfiguration Configuration { get; }
+
+        private ConfigurationHelper()
+        {
+            string configPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\nethermind-node-tests"));
+
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(configPath)
+                .AddJsonFile("config.json");
+
+            Configuration = builder.Build();
+        }
+
+        public string this[string setting]
+        {
+            get { return Configuration[setting]; }
+        }
+    }
+}

--- a/NethermindNode.Core/Helpers/ConfigurationHelper.cs
+++ b/NethermindNode.Core/Helpers/ConfigurationHelper.cs
@@ -18,7 +18,7 @@ namespace NethermindNode.Core.Helpers
 
         private ConfigurationHelper()
         {
-            string configPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\nethermind-node-tests"));
+            string configPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), @"../../../nethermind-node-tests"));
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(configPath)

--- a/NethermindNode.Core/Helpers/DockerCommands.cs
+++ b/NethermindNode.Core/Helpers/DockerCommands.cs
@@ -52,7 +52,7 @@ public static class DockerCommands
 
     public static string GetExecutionDataPath(Logger logger)
     {
-        return GetDockerDetails("sedge-execution-client", "{{ range .Mounts }}{{ if eq .Destination \\\"/nethermind/data\\\" }}{{ .Source }}{{ end }}{{ end }}", logger).Trim();
+        return GetDockerDetails(ConfigurationHelper.Instance["execution-container-name"], "{ { range .Mounts }}{{ if eq .Destination \\\"/nethermind/data\\\" }}{{ .Source }}{{ end }}{{ end }}", logger).Trim();
     }
 
     public static IEnumerable<string> GetDockerLogs(string containerIdOrName, string logFilter = null, bool followLogs = false, CancellationToken? cancellationToken = null, string additionaloptions = "")

--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -46,7 +46,7 @@ public static class NodeInfo
         }
 
         //Waiting for proper start of node
-        //while (DockerCommands.CheckIfDockerContainerIsCreated("sedge-execution-client", logger) == false)
+        //while (DockerCommands.CheckIfDockerContainerIsCreated(ConfigurationHelper.Instance["execution-container-name"], logger) == false)
         //{
         //    logger.Info("Waiting for Execution to be started.");
         //    Thread.Sleep(30000);

--- a/NethermindNode.Core/NethermindNode.Core.csproj
+++ b/NethermindNode.Core/NethermindNode.Core.csproj
@@ -12,6 +12,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Etherscan.Net" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="NLog" Version="5.1.3" />
     <PackageReference Include="Notion.Net" Version="4.1.0" />
   </ItemGroup>

--- a/NethermindNode.Core/NethermindNode.Core.csproj
+++ b/NethermindNode.Core/NethermindNode.Core.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="NLog" Version="5.1.3" />
     <PackageReference Include="Notion.Net" Version="4.1.0" />
+	<None Include="..\config.json" Link="config.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NethermindNode.Tests/Helpers/ConfigurationHelper.cs
+++ b/NethermindNode.Tests/Helpers/ConfigurationHelper.cs
@@ -1,8 +1,0 @@
-﻿using Microsoft.Extensions.Configuration;
-
-namespace NethermindNode.Tests.Helpers;
-
-public static class ConfigurationHelper
-{
-    public static IConfiguration Configuration { get; set; }
-}

--- a/NethermindNode.Tests/Helpers/FuzzerHelper.cs
+++ b/NethermindNode.Tests/Helpers/FuzzerHelper.cs
@@ -13,7 +13,7 @@ public static class FuzzerHelper
 
 public class FuzzerCommandOptions : IFuzzerCommand
 {
-    public string DockerContainerName { get; set; } = "sedge-execution-client";
+    public string DockerContainerName { get; set; } = ConfigurationHelper.Instance["execution-container-name"];
     public bool IsFullySyncedCheck { get; set; }
     public bool ShouldForceKillCommand { get; set; }
     public bool ShouldForceGracefullCommand { get; set; }

--- a/NethermindNode.Tests/Helpers/FuzzerHelper.cs
+++ b/NethermindNode.Tests/Helpers/FuzzerHelper.cs
@@ -13,7 +13,7 @@ public static class FuzzerHelper
 
 public class FuzzerCommandOptions : IFuzzerCommand
 {
-    public string DockerContainerName { get; set; } = ConfigurationHelper.Instance["execution-container-name"];
+    public string DockerContainerName { get; set; }
     public bool IsFullySyncedCheck { get; set; }
     public bool ShouldForceKillCommand { get; set; }
     public bool ShouldForceGracefullCommand { get; set; }

--- a/NethermindNode.Tests/NethermindNode.Tests.csproj
+++ b/NethermindNode.Tests/NethermindNode.Tests.csproj
@@ -43,9 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Update="NLog.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/NethermindNode.Tests/NethermindNode.Tests.csproj
+++ b/NethermindNode.Tests/NethermindNode.Tests.csproj
@@ -36,6 +36,7 @@
     </PackageReference>
     <PackageReference Include="NunitXml.TestLogger" Version="3.0.131" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+	<None Include="..\config.json" Link="config.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NethermindNode.Tests/Tests/BaseTest.cs
+++ b/NethermindNode.Tests/Tests/BaseTest.cs
@@ -6,12 +6,4 @@ namespace NethermindNode.Tests;
 public class BaseTest
 {
 
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        ConfigurationHelper.Configuration = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.json")
-            .AddUserSecrets<BaseTest>(true)
-            .Build();
-    }
 }

--- a/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
+++ b/NethermindNode.Tests/Tests/Pruning/JsonRpcPruning.cs
@@ -80,7 +80,7 @@ namespace NethermindNode.Tests.Tests.Pruning
 
             try
             {
-                foreach (var line in DockerCommands.GetDockerLogs("sedge-execution-client", "Full Pruning", true, cts.Token, "--since 2m")) //since to ensure that we will get only recent logs but including all from beggining of test
+                foreach (var line in DockerCommands.GetDockerLogs(ConfigurationHelper.Instance["execution-container-name"], "Full Pruning", true, cts.Token, "--since 2m")) //since to ensure that we will get only recent logs but including all from beggining of test
                 {
                     Console.WriteLine(line); // For visibility during testing
 

--- a/NethermindNode.Tests/Tests/Resyncs/ResyncOnFullSyncedNode.cs
+++ b/NethermindNode.Tests/Tests/Resyncs/ResyncOnFullSyncedNode.cs
@@ -24,17 +24,17 @@ internal class ResyncOnFullSyncedNode
             }
 
             //Stopping and clearing EL
-            DockerCommands.StopDockerContainer("sedge-execution-client", Logger);
-            while (!DockerCommands.GetDockerContainerStatus("sedge-execution-client", Logger).Contains("exited"))
+            DockerCommands.StopDockerContainer(ConfigurationHelper.Instance["execution-container-name"], Logger);
+            while (!DockerCommands.GetDockerContainerStatus(ConfigurationHelper.Instance["execution-container-name"], Logger).Contains("exited"))
             {
-                Logger.Debug($"Waiting for sedge-execution-client docker status to be \"exited\". Current status: {DockerCommands.GetDockerContainerStatus("sedge-execution-client", Logger)}");
+                Logger.Debug($"Waiting for {ConfigurationHelper.Instance["execution-container-name"]} docker status to be \"exited\". Current status: {DockerCommands.GetDockerContainerStatus(ConfigurationHelper.Instance["execution-container-name"], Logger)}");
                 Thread.Sleep(30000);
             }
             CommandExecutor.RemoveDirectory("/root/execution-data/nethermind_db", Logger);
 
             //Restarting Node - freshSync
             Logger.Info($"Starting a FreshSync. Remaining fresh syncs to be executed: {repeatCount - i - 1}");
-            DockerCommands.StartDockerContainer("sedge-execution-client", Logger);
+            DockerCommands.StartDockerContainer(ConfigurationHelper.Instance["execution-container-name"], Logger);
         }
     }
 }

--- a/NethermindNode.Tests/Tests/Resyncs/ResyncsAfterStages.cs
+++ b/NethermindNode.Tests/Tests/Resyncs/ResyncsAfterStages.cs
@@ -66,15 +66,15 @@ internal class ResyncsAfterStages
     private void StopAndResync()
     {
         //Stopping and clearing EL
-        DockerCommands.StopDockerContainer("sedge-execution-client", Logger);
-        while (!DockerCommands.GetDockerContainerStatus("sedge-execution-client", Logger).Contains("exited"))
+        DockerCommands.StopDockerContainer(ConfigurationHelper.Instance["execution-container-name"], Logger);
+        while (!DockerCommands.GetDockerContainerStatus(ConfigurationHelper.Instance["execution-container-name"], Logger).Contains("exited"))
         {
-            Logger.Debug($"Waiting for sedge-execution-client docker status to be \"exited\". Current status: {DockerCommands.GetDockerContainerStatus("sedge-execution-client", Logger)}");
+            Logger.Debug($"Waiting for {ConfigurationHelper.Instance["execution-container-name"]} docker status to be \"exited\". Current status: {DockerCommands.GetDockerContainerStatus(ConfigurationHelper.Instance["execution-container-name"], Logger)}");
             Thread.Sleep(30000);
         }
         CommandExecutor.RemoveDirectory("/root/execution-data/nethermind_db", Logger);
 
         //Restarting Node - freshSync
-        DockerCommands.StartDockerContainer("sedge-execution-client", Logger);
+        DockerCommands.StartDockerContainer(ConfigurationHelper.Instance["execution-container-name"], Logger);
     }
 }

--- a/NethermindNode.Tests/Tests/SyncedNode/RestartsOnSyncedNode.cs
+++ b/NethermindNode.Tests/Tests/SyncedNode/RestartsOnSyncedNode.cs
@@ -35,7 +35,7 @@ public class RestartsOnSyncedNode : BaseTest
 
         NodeInfo.WaitForNodeToBeReady(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
     }
 
     [Category("SnapSync")]
@@ -69,7 +69,7 @@ public class RestartsOnSyncedNode : BaseTest
 
         NodeInfo.WaitForNodeToBeReady(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
     }
 
     [Category("SnapSync")]
@@ -97,6 +97,6 @@ public class RestartsOnSyncedNode : BaseTest
 
         NodeInfo.WaitForNodeToBeReady(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { IsFullySyncedCheck = true, Count = restartCount, Minimum = minimumWait, Maximum = maximumWait, ShouldForceGracefullCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], IsFullySyncedCheck = true, Count = restartCount, Minimum = minimumWait, Maximum = maximumWait, ShouldForceGracefullCommand = true }, Logger);
     }
 }

--- a/NethermindNode.Tests/Tests/SyncedNode/RestartsOnSyncedNode.cs
+++ b/NethermindNode.Tests/Tests/SyncedNode/RestartsOnSyncedNode.cs
@@ -52,7 +52,7 @@ public class RestartsOnSyncedNode : BaseTest
 
         NodeInfo.WaitForNodeToBeReady(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = "sedge-consensus-client", IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["consensus-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
     }
 
     [Category("SnapSync")]
@@ -86,7 +86,7 @@ public class RestartsOnSyncedNode : BaseTest
 
         NodeInfo.WaitForNodeToBeReady(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = "sedge-consensus-client", IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["consensus-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
     }
 
     [TestCase(0, 60, 120)]

--- a/NethermindNode.Tests/Tests/SyncedNode/RestartsOnSyncedNode.cs
+++ b/NethermindNode.Tests/Tests/SyncedNode/RestartsOnSyncedNode.cs
@@ -34,8 +34,9 @@ public class RestartsOnSyncedNode : BaseTest
         Logger.Info($"***Starting test: ShouldRestartNethermindClientWithIncreasingDelay: {currentDelay} Delay***");
 
         NodeInfo.WaitForNodeToBeReady(Logger);
+        NodeInfo.WaitForNodeToBeSynced(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
     }
 
     [Category("SnapSync")]
@@ -51,8 +52,9 @@ public class RestartsOnSyncedNode : BaseTest
         Logger.Info($"***Starting test: ShouldRestartConsensusClientWithIncreasingDelay: {currentDelay} Delay***");
 
         NodeInfo.WaitForNodeToBeReady(Logger);
+        NodeInfo.WaitForNodeToBeSynced(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["consensus-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["consensus-container-name"], Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceGracefullCommand = true }, Logger);
     }
 
     [Category("SnapSync")]
@@ -68,8 +70,9 @@ public class RestartsOnSyncedNode : BaseTest
         Logger.Info($"***Starting test: ShouldKillNethermindClientWithIncreasingDelay: {currentDelay} Delay***");
 
         NodeInfo.WaitForNodeToBeReady(Logger);
+        NodeInfo.WaitForNodeToBeSynced(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
     }
 
     [Category("SnapSync")]
@@ -85,8 +88,9 @@ public class RestartsOnSyncedNode : BaseTest
         Logger.Info($"***Starting test: ShouldKillConsensusClientWithIncreasingDelay: {currentDelay} Delay***");
 
         NodeInfo.WaitForNodeToBeReady(Logger);
+        NodeInfo.WaitForNodeToBeSynced(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["consensus-container-name"], IsFullySyncedCheck = true, Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["consensus-container-name"], Count = 1, Minimum = currentDelay, Maximum = currentDelay, ShouldForceKillCommand = true }, Logger);
     }
 
     [TestCase(0, 60, 120)]
@@ -96,7 +100,8 @@ public class RestartsOnSyncedNode : BaseTest
         Logger.Info("***Starting test: ShouldRestartGracefullyNodeForInfinityOnSyncedNode***");
 
         NodeInfo.WaitForNodeToBeReady(Logger);
+        NodeInfo.WaitForNodeToBeSynced(Logger);
 
-        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], IsFullySyncedCheck = true, Count = restartCount, Minimum = minimumWait, Maximum = maximumWait, ShouldForceGracefullCommand = true }, Logger);
+        FuzzerHelper.Fuzz(new FuzzerCommandOptions { DockerContainerName = ConfigurationHelper.Instance["execution-container-name"], Count = restartCount, Minimum = minimumWait, Maximum = maximumWait, ShouldForceGracefullCommand = true }, Logger);
     }
 }

--- a/NethermindNode.Tests/appsettings.json
+++ b/NethermindNode.Tests/appsettings.json
@@ -1,6 +1,0 @@
-{
-    "GitHubWorkflowId": "<<RUN_ID>>",
-    "AuthToken": "<<TOKEN>>",
-    "SyncTimesSummaryDatabaseId": "be7549511c3d40a2b449f9f357f8c608",
-    "SyncTimesDetailedDatabaseId": "2102cc3db8a846399d404897c99dbb51"
-}

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+    "execution-container-name": "sedge-execution-client",
+    "consensus-container-name": "sedge-consensus-client"
+}


### PR DESCRIPTION
With that we can use nethermind-node-tests on any other source not only when triggered from Sedge (still must be a setup with 2 dockers for execution and beacon).

Additionally removed Notion deprecated stuff + removed second appsetting which is confusing and was only visible in single project.

Needed by: https://github.com/NethermindEth/post-merge-smoke-tests/pull/83
to achieve this: https://github.com/NethermindEth/ansible-deployments/pull/4