### PR TITLE
Add Receipt Verification tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "nethermind"]
 	path = nethermind
-	url = git@github.com:NethermindEth/nethermind.git
+	url = https://github.com/NethermindEth/nethermind.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nethermind"]
+	path = nethermind
+	url = git@github.com:NethermindEth/nethermind.git

--- a/NethermindNode.Core/Helpers/HttpExecutor.cs
+++ b/NethermindNode.Core/Helpers/HttpExecutor.cs
@@ -18,6 +18,7 @@ public static class HttpExecutor
 
     static public async Task<T> ExecuteAndSerialize<T>(string command, string parameters, string url, Logger logger) where T : IRpcResponse
     {
+        logger.Info($"Executing command: {command} with parameters: {parameters}");
         var response = await ExecuteNethermindJsonRpcCommand(command, parameters, url, logger);
         logger.Info($"Response: {response.Item1}");
         bool isVerifiedPositively = JsonRpcHelper.TryDeserializeReponse<T>(response.Item1, out IRpcResponse deserialized);

--- a/NethermindNode.Core/Helpers/HttpExecutor.cs
+++ b/NethermindNode.Core/Helpers/HttpExecutor.cs
@@ -19,7 +19,10 @@ public static class HttpExecutor
     static public async Task<T> ExecuteAndSerialize<T>(string command, string parameters, string url, Logger logger) where T : IRpcResponse
     {
         var response = await ExecuteNethermindJsonRpcCommand(command, parameters, url, logger);
+        logger.Info($"Response: {response.Item1}");
         bool isVerifiedPositively = JsonRpcHelper.TryDeserializeReponse<T>(response.Item1, out IRpcResponse deserialized);
+        logger.Info(deserialized);
+
         if (!isVerifiedPositively)
         {
             if (deserialized is RpcError)

--- a/NethermindNode.Core/Helpers/JsonRpcHelper.cs
+++ b/NethermindNode.Core/Helpers/JsonRpcHelper.cs
@@ -5,9 +5,9 @@ namespace NethermindNode.Core.Helpers;
 
 public static class JsonRpcHelper
 {
-    public static bool TryDeserializeReponse<T>(string result, out IRpcResponse deserialized) where T : IRpcResponse
+    public static bool TryDeserializeReponse<T>(string result, out IRpcResponse? deserialized) where T : IRpcResponse
     {
-        deserialized = default;
+        deserialized = null;
         try
         {
             RpcError error = JsonConvert.DeserializeObject<RpcError>(result);

--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -140,7 +140,7 @@ public static class NodeInfo
 
     public static async Task<SingleResult> GetConfigValue(Logger logger, string category, string key)
     {
-        var res = await HttpExecutor.ExecuteAndSerialize<SingleResult>("debug_getConfigValue", $"[\"{category}\", \"{key}\"]", "http://localhost:8545", logger);
+        var res = await HttpExecutor.ExecuteAndSerialize<SingleResult>("debug_getConfigValue", $"\"{category}\", \"{key}\"", "http://localhost:8545", logger);
         return res;
     }
 

--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -123,9 +123,9 @@ public static class NodeInfo
         }
     }
 
-    public static NetworkType GetNetworkType(Logger logger)
+    public static async Task<NetworkType> GetNetworkType(Logger logger)
     {
-        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("eth_chainId", "", "http://localhost:8545", logger);
+        var commandResult = await HttpExecutor.ExecuteAndSerialize<SingleResult>("eth_chainId", "", "http://localhost:8545", logger);
         var result = commandResult.Result;
         if (result == null)
         {
@@ -133,38 +133,38 @@ public static class NodeInfo
         }
         else
         {
-            return (NetworkType)int.Parse(result.Item1, System.Globalization.NumberStyles.HexNumber);
+            logger.Info($"Network type: {result}");
+            return (NetworkType)int.Parse(result, System.Globalization.NumberStyles.HexNumber);
         }
     }
 
-    public static Tuple<string, TimeSpan, bool>? GetConfigValue(Logger logger, string category, string key)
+    public static async Task<SingleResult> GetConfigValue(Logger logger, string category, string key)
     {
-        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("debug_getConfigValue", $"[\"{category}\", \"{key}\"]", "http://localhost:8545", logger);
-        return commandResult.Result;
+        var res = await HttpExecutor.ExecuteAndSerialize<SingleResult>("debug_getConfigValue", $"[\"{category}\", \"{key}\"]", "http://localhost:8545", logger);
+        return res;
     }
 
 
-    public static long GetPivotNumber(Logger logger)
+    public static async Task<long> GetPivotNumber(Logger logger)
     {
-        var result = GetConfigValue(logger, "Sync", "PivotNumber");
-        if (result == null)
-        {
-
-            return 0;
-        }
-
-        return long.Parse(result.Item1);
-    }
-
-    public static long GetAncientReceiptsBarrier(Logger logger)
-    {
-        var result = GetConfigValue(logger, "Sync", "AncientReceiptsBarrier");
-        if (result == null)
+        var result = await GetConfigValue(logger, "Sync", "PivotNumber");
+        if (result.Result == null)
         {
             return 0;
         }
 
-        return long.Parse(result.Item1);
+        return long.Parse(result.Result);
+    }
+
+    public static async Task<long> GetAncientReceiptsBarrier(Logger logger)
+    {
+        var result = await GetConfigValue(logger, "Sync", "AncientReceiptsBarrier");
+        if (result.Result == null)
+        {
+            return 0;
+        }
+
+        return long.Parse(result.Result);
     }
 
 }

--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -7,7 +7,8 @@ namespace NethermindNode.Core.Helpers;
 public static class NodeInfo
 {
     private static readonly HttpClient client = new HttpClient();
-    private static readonly string apiBaseUrl = "http://localhost:8545";
+    public static readonly string apiBaseUrl = "http://localhost:8545";
+    public static readonly string wsBaseUrl = "ws://localhost:8545";
 
     public enum NetworkType
     {
@@ -22,7 +23,7 @@ public static class NodeInfo
 
     public static bool IsFullySynced(Logger logger)
     {
-        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("eth_syncing", "", "http://localhost:8545", logger);
+        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("eth_syncing", "", apiBaseUrl, logger);
         var result = commandResult.Result;
         return result == null ? false : result.Item1.Contains("false");
     }
@@ -66,7 +67,7 @@ public static class NodeInfo
 
     public static string GetCurrentStage(NLog.Logger logger)
     {
-        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("debug_getSyncStage", "", "http://localhost:8545", logger);
+        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("debug_getSyncStage", "", apiBaseUrl, logger);
         string output = "";
 
         bool isVerifiedPositively = JsonRpcHelper.TryDeserializeReponse<GetSyncStage>(commandResult.Result.Item1, out IRpcResponse deserialized);
@@ -87,7 +88,7 @@ public static class NodeInfo
     public static List<Stages> GetCurrentStages(NLog.Logger logger)
     {
         List<Stages> result = new List<Stages>();
-        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("debug_getSyncStage", "", "http://localhost:8545", logger);
+        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("debug_getSyncStage", "", apiBaseUrl, logger);
         string output = "";
 
         bool isVerifiedPositively = JsonRpcHelper.TryDeserializeReponse<GetSyncStage>(commandResult.Result.Item1, out IRpcResponse deserialized);
@@ -125,7 +126,7 @@ public static class NodeInfo
 
     public static async Task<NetworkType> GetNetworkType(Logger logger)
     {
-        var commandResult = await HttpExecutor.ExecuteAndSerialize<SingleResult>("eth_chainId", "", "http://localhost:8545", logger);
+        var commandResult = await HttpExecutor.ExecuteAndSerialize<SingleResult>("eth_chainId", "", apiBaseUrl, logger);
         var result = commandResult.Result;
         if (result == null)
         {
@@ -140,7 +141,7 @@ public static class NodeInfo
 
     public static async Task<SingleResult> GetConfigValue(Logger logger, string category, string key)
     {
-        var res = await HttpExecutor.ExecuteAndSerialize<SingleResult>("debug_getConfigValue", $"\"{category}\", \"{key}\"", "http://localhost:8545", logger);
+        var res = await HttpExecutor.ExecuteAndSerialize<SingleResult>("debug_getConfigValue", $"\"{category}\", \"{key}\"", apiBaseUrl, logger);
         return res;
     }
 

--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -9,14 +9,25 @@ public static class NodeInfo
     private static readonly HttpClient client = new HttpClient();
     private static readonly string apiBaseUrl = "http://localhost:8545";
 
-    public static bool IsFullySynced(NLog.Logger logger)
+    public enum NetworkType
+    {
+        Mainnet = 1,
+        EnergyWeb = 246,
+        Gnosis = 100,
+        Chiado = 10200,
+        Volta = 73799,
+        Sepolia = 11155111,
+        Holesky = 17000,
+    }
+
+    public static bool IsFullySynced(Logger logger)
     {
         var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("eth_syncing", "", "http://localhost:8545", logger);
         var result = commandResult.Result;
         return result == null ? false : result.Item1.Contains("false");
     }
 
-    public static void WaitForNodeToBeReady(NLog.Logger logger)
+    public static void WaitForNodeToBeReady(Logger logger)
     {
         var apiIsAvailable = false;
 
@@ -111,4 +122,49 @@ public static class NodeInfo
             Thread.Sleep(10000);
         }
     }
+
+    public static NetworkType GetNetworkType(Logger logger)
+    {
+        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("eth_chainId", "", "http://localhost:8545", logger);
+        var result = commandResult.Result;
+        if (result == null)
+        {
+            return NetworkType.Mainnet;
+        }
+        else
+        {
+            return (NetworkType)int.Parse(result.Item1, System.Globalization.NumberStyles.HexNumber);
+        }
+    }
+
+    public static Tuple<string, TimeSpan, bool>? GetConfigValue(Logger logger, string category, string key)
+    {
+        var commandResult = HttpExecutor.ExecuteNethermindJsonRpcCommand("debug_getConfigValue", $"[\"{category}\", \"{key}\"]", "http://localhost:8545", logger);
+        return commandResult.Result;
+    }
+
+
+    public static long GetPivotNumber(Logger logger)
+    {
+        var result = GetConfigValue(logger, "Sync", "PivotNumber");
+        if (result == null)
+        {
+
+            return 0;
+        }
+
+        return long.Parse(result.Item1);
+    }
+
+    public static long GetAncientReceiptsBarrier(Logger logger)
+    {
+        var result = GetConfigValue(logger, "Sync", "AncientReceiptsBarrier");
+        if (result == null)
+        {
+            return 0;
+        }
+
+        return long.Parse(result.Item1);
+    }
+
 }

--- a/NethermindNode.Core/RpcResponses/SingleResult.cs
+++ b/NethermindNode.Core/RpcResponses/SingleResult.cs
@@ -1,0 +1,11 @@
+namespace NethermindNode.Core.RpcResponses
+{
+  // Generic single string result response
+  public class SingleResult : IRpcResponse
+  {
+    public string Jsonrpc { get; set; }
+    public string Result { get; set; }
+    public int Id { get; set; }
+  }
+
+}

--- a/NethermindNode.Tests/NethermindNode.Tests.csproj
+++ b/NethermindNode.Tests/NethermindNode.Tests.csproj
@@ -21,8 +21,10 @@
     <PackageReference Include="Hardware.Info" Version="11.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Nethereum.JsonRpc.WebSocketClient" Version="4.21.0" />
+    <PackageReference Include="Nethereum.RPC.Reactive" Version="4.21.0" />
     <PackageReference Include="Nethereum.Web3" Version="4.14.0" />
-    <PackageReference Include="NLog" Version="5.1.3" />
+    <PackageReference Include="NLog" Version="5.3.2" />
     <PackageReference Include="Notion.Net" Version="4.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
@@ -35,12 +37,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NunitXml.TestLogger" Version="3.0.131" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
 	<None Include="..\config.json" Link="config.json" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\NethermindNode.SedgeFuzzer\NethermindNode.SedgeFuzzer.csproj" />
+    <ProjectReference Include="..\nethermind\src\Nethermind\Nethermind.Runner\Nethermind.Runner.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -26,27 +26,25 @@ class ReceiptsHelper
     {
       Logger.Info($"Converting {JsonConvert.SerializeObject(receipts[i])}");
       // var entry = JsonConvert.DeserializeObject<LogEntry>(JsonConvert.SerializeObject(receipts[i].Logs[0]));
-      var rcp = new TxReceipt
-      {
-        // rcp.Logs = receipts[i].Logs.Select(l => new LogEntry(new Address(l.Address), l.Data.ToBytes(), l.Topics.Select(t => new Hash256(t)).ToArray())).ToArray(),
-        Bloom = new Bloom(receipts[i].LogsBloom.ToBytes()),
+      var rcp = new TxReceipt();
+      // rcp.Logs = receipts[i].Logs.Select(l => new LogEntry(new Address(l.Address), l.Data.ToBytes(), l.Topics.Select(t => new Hash256(t)).ToArray())).ToArray(),
+      rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
 
-        // ??? not sure it's the right field
-        PostTransactionState = new Hash256(receipts[i].Root),
-        ReturnValue = receipts[i].Status.HexValue.ToBytes(),
+      // ??? not sure it's the right field
+      rcp.PostTransactionState = new Hash256(receipts[i].Root);
+      rcp.ReturnValue = receipts[i].Status.HexValue.ToBytes();
 
-        Recipient = new Address(receipts[i].To),
-        ContractAddress = receipts[i].ContractAddress != null ? new Address(receipts[i].ContractAddress) : null,
-        Sender = new Address(receipts[i].From),
-        GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value,
-        GasUsed = (long)receipts[i].GasUsed.Value,
-        Index = (int)receipts[i].TransactionIndex.Value,
-        TxHash = new Hash256(receipts[i].TransactionHash),
-        BlockHash = new Hash256(receipts[i].BlockHash),
-        BlockNumber = (long)receipts[i].BlockNumber.Value,
-        StatusCode = receipts[i].Status.HexValue.ToBytes()[0],
-        TxType = (TxType)(byte)receipts[i].Type.Value
-      };
+      rcp.Recipient = new Address(receipts[i].To);
+      rcp.ContractAddress = receipts[i].ContractAddress != null ? new Address(receipts[i].ContractAddress) : null;
+      rcp.Sender = new Address(receipts[i].From);
+      rcp.GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value;
+      rcp.GasUsed = (long)receipts[i].GasUsed.Value;
+      rcp.Index = (int)receipts[i].TransactionIndex.Value;
+      rcp.TxHash = new Hash256(receipts[i].TransactionHash);
+      rcp.BlockHash = new Hash256(receipts[i].BlockHash);
+      rcp.BlockNumber = (long)receipts[i].BlockNumber.Value;
+      rcp.StatusCode = receipts[i].Status.HexValue.ToBytes()[0];
+      rcp.TxType = (TxType)(byte)receipts[i].Type.Value;
 
       for (int j = 0; j < receipts[i].Logs.Count; j++)
       {

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -1,0 +1,72 @@
+
+
+using Nethereum.Hex.HexTypes;
+using Nethereum.RPC.Eth.DTOs;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.Tracing.GethStyle.Custom.JavaScript;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Specs;
+using Nethermind.State.Proofs;
+
+class ReceiptsHelper
+{
+
+  ReleaseSpec spec = new ReleaseSpec() { ValidateReceipts = false };
+
+  private static TxReceipt[] ConvertReceipts(TransactionReceipt[] receipts)
+  {
+
+    TxReceipt[] txReceipts = new TxReceipt[receipts.Length];
+    for (int i = 0; i < receipts.Length; i++)
+    {
+      var rcp = new TxReceipt();
+      rcp.BlockHash = new Hash256(receipts[i].BlockHash);
+      rcp.BlockNumber = (long)receipts[i].BlockNumber.Value;
+      rcp.ContractAddress = new Address(receipts[i].ContractAddress);
+
+      // rcp.Logs = receipts[i].Logs.Select(l => new LogEntry()
+      // {
+      //   address = new Address(l.Address),
+      //   data = l.Data.ToBytes(),
+      //   topics = l.Topics.Select(t => new Hash256(t)).ToArray()
+      // }).ToArray();
+      rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
+
+      // ??? not sure it's the right field
+      rcp.PostTransactionState = new Hash256(receipts[i].Root);
+      rcp.ReturnValue = receipts[i].Status.HexValue.ToBytes();
+
+      rcp.Recipient = new Address(receipts[i].To);
+      rcp.ContractAddress = new Address(receipts[i].ContractAddress);
+      rcp.Sender = new Address(receipts[i].From);
+      rcp.GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value;
+      rcp.GasUsed = (long)receipts[i].GasUsed.Value;
+      rcp.Index = (int)receipts[i].TransactionIndex.Value;
+      rcp.TxHash = new Hash256(receipts[i].TransactionHash);
+      rcp.BlockHash = new Hash256(receipts[i].BlockHash);
+      rcp.BlockNumber = (long)receipts[i].BlockNumber.Value;
+      rcp.StatusCode = receipts[i].Status.HexValue.ToBytes()[0];
+      rcp.TxType = (TxType)(byte)receipts[i].Type.Value;
+
+      txReceipts[i] = rcp;
+    }
+
+    return txReceipts;
+  }
+
+  public static string CalculateRoot(TransactionReceipt[] receipts)
+  {
+    // Calculate the root hash of the receipts
+
+    var txReceipts = ConvertReceipts(receipts);
+    return ReceiptsRootCalculator.Instance.GetReceiptsRoot(txReceipts, new ReleaseSpec() { ValidateReceipts = false }, new Hash256("0x0")).ToString();
+
+    // var spec = new ReleaseSpec() { ValidateReceipts = false };
+    // var _decoder = Rlp.GetStreamDecoder<TxReceipt>(RlpDecoderKey.Trie);
+    // Hash256 receiptsRoot = ReceiptTrie<TxReceipt>.CalculateRoot(spec, receipts, _decoder);
+
+
+  }
+}

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -46,6 +46,7 @@ class ReceiptsHelper
       rcp.StatusCode = receipts[i].Status.HexValue.ToBytes()[0];
       rcp.TxType = (TxType)(byte)receipts[i].Type.Value;
 
+      rcp.Logs = new LogEntry[receipts[i].Logs.Count];
       for (int j = 0; j < receipts[i].Logs.Count; j++)
       {
         // var entry = JsonConvert.DeserializeObject<LogEntry>(receipts[i].Logs[j]);

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -52,12 +52,12 @@ class ReceiptsHelper
         var log = receipts[i].Logs[j];
         var addr = new Address(log["address"].ToString());
         // var data = log["data"].ToBytes();
-        var data = log.Value<string>("data")?.ToBytes();
-        var topics = log["topics"].Select(t => new Hash256(t.ToString())).ToArray();
-        Logger.Info($"Log!!!: {addr} {data} {topics}");
+        byte[] data = log.Value<string>("data")?.ToBytes();
+        Hash256[] topics = log["topics"].Select(t => new Hash256(t.ToString())).ToArray();
+        Logger.Info($"Log!!!: {addr} {data} {data.Count()} {topics} {topics.Count()}");
         var entry = new LogEntry(addr, data, topics);
 
-        Logger.Info($"Log: {JsonConvert.SerializeObject(entry)}");
+        // Logger.Info($"Log: {JsonConvert.SerializeObject(entry)}");
 
         rcp.Logs[j] = entry;
         // rcp.Logs[j] = new LogEntry(new Address(receipts[i].Logs[j].Address), receipts[i].Logs[j].Data.ToBytes(), receipts[i].Logs[j].Topics.Select(t => new Hash256(t)).ToArray());

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -17,15 +17,13 @@ class ReceiptsHelper
 
   private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger(TestContext.CurrentContext.Test.Name);
 
-  ReleaseSpec spec = new ReleaseSpec() { ValidateReceipts = false };
-
   private static TxReceipt[] ConvertReceipts(TransactionReceipt[] receipts)
   {
 
     TxReceipt[] txReceipts = new TxReceipt[receipts.Length];
     for (int i = 0; i < receipts.Length; i++)
     {
-      Logger.Info($"Converting {JsonConvert.SerializeObject(receipts[i])}");
+      // Logger.Info($"Converting {JsonConvert.SerializeObject(receipts[i])}");
       var rcp = new TxReceipt();
       rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
 
@@ -57,7 +55,7 @@ class ReceiptsHelper
       }
 
       txReceipts[i] = rcp;
-      Logger.Info($"Converted: {i}");
+      // Logger.Info($"Converted: {i}");
     }
 
     return txReceipts;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -48,7 +48,10 @@ class ReceiptsHelper
 
       for (int j = 0; j < receipts[i].Logs.Count; j++)
       {
-        var entry = JsonConvert.DeserializeObject<LogEntry>(JsonConvert.SerializeObject(receipts[i].Logs[j]));
+        // var entry = JsonConvert.DeserializeObject<LogEntry>(receipts[i].Logs[j]);
+        var log = receipts[i].Logs[j];
+        var entry = new LogEntry(new Address(log["address"]?.ToString()), log["data"].ToBytes(), log["topics"].Select(t => new Hash256(t.ToString())).ToArray());
+
         Logger.Info($"Log: {JsonConvert.SerializeObject(entry)}");
 
         rcp.Logs[j] = entry;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -31,11 +31,11 @@ class ReceiptsHelper
       rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
 
       // ??? not sure it's the right field
-      rcp.PostTransactionState = new Hash256(receipts[i].Root);
+      rcp.PostTransactionState = receipts[i].Root == null ? null : new Hash256(receipts[i].Root);
       rcp.ReturnValue = receipts[i].Status.HexValue.ToBytes();
 
       rcp.Recipient = new Address(receipts[i].To);
-      rcp.ContractAddress = receipts[i].ContractAddress != null ? new Address(receipts[i].ContractAddress) : null;
+      rcp.ContractAddress = receipts[i].ContractAddress == null ? null : new Address(receipts[i].ContractAddress);
       rcp.Sender = new Address(receipts[i].From);
       rcp.GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value;
       rcp.GasUsed = (long)receipts[i].GasUsed.Value;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -23,7 +23,7 @@ class ReceiptsHelper
     TxReceipt[] txReceipts = new TxReceipt[receipts.Length];
     for (int i = 0; i < receipts.Length; i++)
     {
-      Logger.Info($"\n\nConverting {JsonConvert.SerializeObject(receipts[i])}");
+      // Logger.Info($"\n\nConverting {JsonConvert.SerializeObject(receipts[i])}");
       var rcp = new TxReceipt();
       rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
 
@@ -64,10 +64,10 @@ class ReceiptsHelper
   public static string CalculateRoot(TransactionReceipt[] receipts)
   {
     // Calculate the root hash of the receipts
-    Logger.Info($"CalculateRoot: {receipts.Length}");
+    // Logger.Info($"CalculateRoot: {receipts.Length}");
 
     var txReceipts = ConvertReceipts(receipts);
-    Logger.Info($"txReceipts: {txReceipts.Length}");
+    // Logger.Info($"txReceipts: {txReceipts.Length}");
 
     // return ReceiptsRootCalculator.Instance.GetReceiptsRoot(txReceipts, new ReleaseSpec() { ValidateReceipts = false }, new Hash256("0x0")).ToString();
 

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -23,7 +23,7 @@ class ReceiptsHelper
     TxReceipt[] txReceipts = new TxReceipt[receipts.Length];
     for (int i = 0; i < receipts.Length; i++)
     {
-      // Logger.Info($"Converting {JsonConvert.SerializeObject(receipts[i])}");
+      Logger.Info($"\n\nConverting {JsonConvert.SerializeObject(receipts[i])}");
       var rcp = new TxReceipt();
       rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
 
@@ -55,7 +55,7 @@ class ReceiptsHelper
       }
 
       txReceipts[i] = rcp;
-      // Logger.Info($"Converted: {i}");
+      Logger.Info($"Converted: {i}");
     }
 
     return txReceipts;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -25,14 +25,10 @@ class ReceiptsHelper
     for (int i = 0; i < receipts.Length; i++)
     {
       Logger.Info($"Converting {JsonConvert.SerializeObject(receipts[i])}");
+      // var entry = JsonConvert.DeserializeObject<LogEntry>(JsonConvert.SerializeObject(receipts[i].Logs[0]));
       var rcp = new TxReceipt
       {
-        // rcp.Logs = receipts[i].Logs.Select(l => new LogEntry()
-        // {
-        //   address = new Address(l.Address),
-        //   data = l.Data.ToBytes(),
-        //   topics = l.Topics.Select(t => new Hash256(t)).ToArray()
-        // }).ToArray();
+        // rcp.Logs = receipts[i].Logs.Select(l => new LogEntry(new Address(l.Address), l.Data.ToBytes(), l.Topics.Select(t => new Hash256(t)).ToArray())).ToArray(),
         Bloom = new Bloom(receipts[i].LogsBloom.ToBytes()),
 
         // ??? not sure it's the right field
@@ -40,7 +36,7 @@ class ReceiptsHelper
         ReturnValue = receipts[i].Status.HexValue.ToBytes(),
 
         Recipient = new Address(receipts[i].To),
-        ContractAddress = new Address(receipts[i].ContractAddress),
+        ContractAddress = receipts[i].ContractAddress != null ? new Address(receipts[i].ContractAddress) : null,
         Sender = new Address(receipts[i].From),
         GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value,
         GasUsed = (long)receipts[i].GasUsed.Value,
@@ -51,6 +47,15 @@ class ReceiptsHelper
         StatusCode = receipts[i].Status.HexValue.ToBytes()[0],
         TxType = (TxType)(byte)receipts[i].Type.Value
       };
+
+      for (int j = 0; j < receipts[i].Logs.Count; j++)
+      {
+        var entry = JsonConvert.DeserializeObject<LogEntry>(JsonConvert.SerializeObject(receipts[i].Logs[j]));
+        Logger.Info($"Log: {JsonConvert.SerializeObject(entry)}");
+
+        rcp.Logs[j] = entry;
+        // rcp.Logs[j] = new LogEntry(new Address(receipts[i].Logs[j].Address), receipts[i].Logs[j].Data.ToBytes(), receipts[i].Logs[j].Topics.Select(t => new Hash256(t)).ToArray());
+      }
 
       txReceipts[i] = rcp;
       Logger.Info($"Converted: {i}");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -9,6 +9,7 @@ using Nethermind.Evm.Tracing.GethStyle.Custom.JavaScript;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.State.Proofs;
+using Newtonsoft.Json;
 
 class ReceiptsHelper
 {
@@ -23,34 +24,33 @@ class ReceiptsHelper
     TxReceipt[] txReceipts = new TxReceipt[receipts.Length];
     for (int i = 0; i < receipts.Length; i++)
     {
-      var rcp = new TxReceipt();
-      rcp.BlockHash = new Hash256(receipts[i].BlockHash);
-      rcp.BlockNumber = (long)receipts[i].BlockNumber.Value;
-      rcp.ContractAddress = new Address(receipts[i].ContractAddress);
+      Logger.Info($"Converting {JsonConvert.SerializeObject(receipts[i])}");
+      var rcp = new TxReceipt
+      {
+        // rcp.Logs = receipts[i].Logs.Select(l => new LogEntry()
+        // {
+        //   address = new Address(l.Address),
+        //   data = l.Data.ToBytes(),
+        //   topics = l.Topics.Select(t => new Hash256(t)).ToArray()
+        // }).ToArray();
+        Bloom = new Bloom(receipts[i].LogsBloom.ToBytes()),
 
-      // rcp.Logs = receipts[i].Logs.Select(l => new LogEntry()
-      // {
-      //   address = new Address(l.Address),
-      //   data = l.Data.ToBytes(),
-      //   topics = l.Topics.Select(t => new Hash256(t)).ToArray()
-      // }).ToArray();
-      rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
+        // ??? not sure it's the right field
+        PostTransactionState = new Hash256(receipts[i].Root),
+        ReturnValue = receipts[i].Status.HexValue.ToBytes(),
 
-      // ??? not sure it's the right field
-      rcp.PostTransactionState = new Hash256(receipts[i].Root);
-      rcp.ReturnValue = receipts[i].Status.HexValue.ToBytes();
-
-      rcp.Recipient = new Address(receipts[i].To);
-      rcp.ContractAddress = new Address(receipts[i].ContractAddress);
-      rcp.Sender = new Address(receipts[i].From);
-      rcp.GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value;
-      rcp.GasUsed = (long)receipts[i].GasUsed.Value;
-      rcp.Index = (int)receipts[i].TransactionIndex.Value;
-      rcp.TxHash = new Hash256(receipts[i].TransactionHash);
-      rcp.BlockHash = new Hash256(receipts[i].BlockHash);
-      rcp.BlockNumber = (long)receipts[i].BlockNumber.Value;
-      rcp.StatusCode = receipts[i].Status.HexValue.ToBytes()[0];
-      rcp.TxType = (TxType)(byte)receipts[i].Type.Value;
+        Recipient = new Address(receipts[i].To),
+        ContractAddress = new Address(receipts[i].ContractAddress),
+        Sender = new Address(receipts[i].From),
+        GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value,
+        GasUsed = (long)receipts[i].GasUsed.Value,
+        Index = (int)receipts[i].TransactionIndex.Value,
+        TxHash = new Hash256(receipts[i].TransactionHash),
+        BlockHash = new Hash256(receipts[i].BlockHash),
+        BlockNumber = (long)receipts[i].BlockNumber.Value,
+        StatusCode = receipts[i].Status.HexValue.ToBytes()[0],
+        TxType = (TxType)(byte)receipts[i].Type.Value
+      };
 
       txReceipts[i] = rcp;
       Logger.Info($"Converted: {i}");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -13,6 +13,8 @@ using Nethermind.State.Proofs;
 class ReceiptsHelper
 {
 
+  private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger(TestContext.CurrentContext.Test.Name);
+
   ReleaseSpec spec = new ReleaseSpec() { ValidateReceipts = false };
 
   private static TxReceipt[] ConvertReceipts(TransactionReceipt[] receipts)
@@ -59,8 +61,12 @@ class ReceiptsHelper
   public static string CalculateRoot(TransactionReceipt[] receipts)
   {
     // Calculate the root hash of the receipts
+    Logger.Info($"CalculateRoot: {receipts.Length}");
+
 
     var txReceipts = ConvertReceipts(receipts);
+    Logger.Info($"txReceipts: {txReceipts.Length}");
+
     return ReceiptsRootCalculator.Instance.GetReceiptsRoot(txReceipts, new ReleaseSpec() { ValidateReceipts = false }, new Hash256("0x0")).ToString();
 
     // var spec = new ReleaseSpec() { ValidateReceipts = false };

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -51,9 +51,10 @@ class ReceiptsHelper
         // var entry = JsonConvert.DeserializeObject<LogEntry>(receipts[i].Logs[j]);
         var log = receipts[i].Logs[j];
         var addr = new Address(log["address"].ToString());
-        var data = log["data"].ToBytes();
+        // var data = log["data"].ToBytes();
+        var data = log.Value<string>("data")?.ToBytes();
         var topics = log["topics"].Select(t => new Hash256(t.ToString())).ToArray();
-        Logger.Info($"Log: {addr} {data} {topics}");
+        Logger.Info($"Log!!!: {addr} {data} {topics}");
         var entry = new LogEntry(addr, data, topics);
 
         Logger.Info($"Log: {JsonConvert.SerializeObject(entry)}");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -55,7 +55,7 @@ class ReceiptsHelper
       }
 
       txReceipts[i] = rcp;
-      Logger.Info($"Converted: {i}");
+      // Logger.Info($"Converted: {i}");
     }
 
     return txReceipts;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -76,12 +76,10 @@ class ReceiptsHelper
     var txReceipts = ConvertReceipts(receipts);
     Logger.Info($"txReceipts: {txReceipts.Length}");
 
-    return ReceiptsRootCalculator.Instance.GetReceiptsRoot(txReceipts, new ReleaseSpec() { ValidateReceipts = false }, new Hash256("0x0")).ToString();
+    // return ReceiptsRootCalculator.Instance.GetReceiptsRoot(txReceipts, new ReleaseSpec() { ValidateReceipts = false }, new Hash256("0x0")).ToString();
 
-    // var spec = new ReleaseSpec() { ValidateReceipts = false };
-    // var _decoder = Rlp.GetStreamDecoder<TxReceipt>(RlpDecoderKey.Trie);
-    // Hash256 receiptsRoot = ReceiptTrie<TxReceipt>.CalculateRoot(spec, receipts, _decoder);
-
-
+    var spec = new ReleaseSpec() { ValidateReceipts = false };
+    var _decoder = Rlp.GetStreamDecoder<TxReceipt>(RlpDecoderKey.Trie);
+    return ReceiptTrie<TxReceipt>.CalculateRoot(spec, txReceipts, _decoder).ToString();
   }
 }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -31,7 +31,7 @@ class ReceiptsHelper
       rcp.PostTransactionState = receipts[i].Root == null ? null : new Hash256(receipts[i].Root);
       rcp.ReturnValue = receipts[i].Status.HexValue.ToBytes();
 
-      rcp.Recipient = new Address(receipts[i].To);
+      rcp.Recipient = receipts[i].To == null ? null : new Address(receipts[i].To);
       rcp.ContractAddress = receipts[i].ContractAddress == null ? null : new Address(receipts[i].ContractAddress);
       rcp.Sender = new Address(receipts[i].From);
       rcp.GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -53,6 +53,7 @@ class ReceiptsHelper
       rcp.TxType = (TxType)(byte)receipts[i].Type.Value;
 
       txReceipts[i] = rcp;
+      Logger.Info($"Converted: {i}");
     }
 
     return txReceipts;
@@ -62,7 +63,6 @@ class ReceiptsHelper
   {
     // Calculate the root hash of the receipts
     Logger.Info($"CalculateRoot: {receipts.Length}");
-
 
     var txReceipts = ConvertReceipts(receipts);
     Logger.Info($"txReceipts: {txReceipts.Length}");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -55,11 +55,8 @@ class ReceiptsHelper
         byte[] data = log.Value<string>("data")?.ToBytes();
         Hash256[] topics = log["topics"].Select(t => new Hash256(t.ToString())).ToArray();
         Logger.Info($"Log!!!: {addr} {data} {data.Count()} {topics} {topics.Count()}");
-        var entry = new LogEntry(addr, data, topics);
 
-        // Logger.Info($"Log: {JsonConvert.SerializeObject(entry)}");
-
-        rcp.Logs[j] = entry;
+        rcp.Logs[j] = new LogEntry(addr, data, topics);
         // rcp.Logs[j] = new LogEntry(new Address(receipts[i].Logs[j].Address), receipts[i].Logs[j].Data.ToBytes(), receipts[i].Logs[j].Topics.Select(t => new Hash256(t)).ToArray());
       }
 

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -50,7 +50,11 @@ class ReceiptsHelper
       {
         // var entry = JsonConvert.DeserializeObject<LogEntry>(receipts[i].Logs[j]);
         var log = receipts[i].Logs[j];
-        var entry = new LogEntry(new Address(log["address"]?.ToString()), log["data"].ToBytes(), log["topics"].Select(t => new Hash256(t.ToString())).ToArray());
+        var addr = new Address(log["address"].ToString());
+        var data = log["data"].ToBytes();
+        var topics = log["topics"].Select(t => new Hash256(t.ToString())).ToArray();
+        Logger.Info($"Log: {addr} {data} {topics}");
+        var entry = new LogEntry(addr, data, topics);
 
         Logger.Info($"Log: {JsonConvert.SerializeObject(entry)}");
 

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsHelper.cs
@@ -1,49 +1,37 @@
-
-
-using Nethereum.Hex.HexTypes;
 using Nethereum.RPC.Eth.DTOs;
-using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.Evm.Tracing.GethStyle.Custom.JavaScript;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.State.Proofs;
-using Newtonsoft.Json;
 
 class ReceiptsHelper
 {
-
-  private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger(TestContext.CurrentContext.Test.Name);
-
   private static TxReceipt[] ConvertReceipts(TransactionReceipt[] receipts)
   {
 
     TxReceipt[] txReceipts = new TxReceipt[receipts.Length];
     for (int i = 0; i < receipts.Length; i++)
     {
-      // Logger.Info($"\n\nConverting {JsonConvert.SerializeObject(receipts[i])}");
-      var rcp = new TxReceipt();
-      rcp.Bloom = new Bloom(receipts[i].LogsBloom.ToBytes());
-
-      // ??? not sure it's the right field
-      rcp.PostTransactionState = receipts[i].Root == null ? null : new Hash256(receipts[i].Root);
-      rcp.ReturnValue = receipts[i].Status.HexValue.ToBytes();
-
-      rcp.Recipient = receipts[i].To == null ? null : new Address(receipts[i].To);
-      rcp.ContractAddress = receipts[i].ContractAddress == null ? null : new Address(receipts[i].ContractAddress);
-      rcp.Sender = new Address(receipts[i].From);
-      rcp.GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value;
-      rcp.GasUsed = (long)receipts[i].GasUsed.Value;
-      rcp.Index = (int)receipts[i].TransactionIndex.Value;
-      rcp.TxHash = new Hash256(receipts[i].TransactionHash);
-      rcp.BlockHash = new Hash256(receipts[i].BlockHash);
-      rcp.BlockNumber = (long)receipts[i].BlockNumber.Value;
-      rcp.StatusCode = receipts[i].Status.HexValue.ToBytes()[0];
-      rcp.TxType = (TxType)(byte)receipts[i].Type.Value;
-
-      rcp.Logs = new LogEntry[receipts[i].Logs.Count];
+      var rcp = new TxReceipt
+      {
+        Bloom = new Bloom(receipts[i].LogsBloom.ToBytes()),
+        PostTransactionState = receipts[i].Root == null ? null : new Hash256(receipts[i].Root),
+        ReturnValue = receipts[i].Status.HexValue.ToBytes(),
+        Recipient = receipts[i].To == null ? null : new Address(receipts[i].To),
+        ContractAddress = receipts[i].ContractAddress == null ? null : new Address(receipts[i].ContractAddress),
+        Sender = new Address(receipts[i].From),
+        GasUsedTotal = (long)receipts[i].CumulativeGasUsed.Value,
+        GasUsed = (long)receipts[i].GasUsed.Value,
+        Index = (int)receipts[i].TransactionIndex.Value,
+        TxHash = new Hash256(receipts[i].TransactionHash),
+        BlockHash = new Hash256(receipts[i].BlockHash),
+        BlockNumber = (long)receipts[i].BlockNumber.Value,
+        StatusCode = receipts[i].Status.HexValue.ToBytes()[0],
+        TxType = (TxType)(byte)receipts[i].Type.Value,
+        Logs = new LogEntry[receipts[i].Logs.Count]
+      };
       for (int j = 0; j < receipts[i].Logs.Count; j++)
       {
         var log = receipts[i].Logs[j];
@@ -55,7 +43,6 @@ class ReceiptsHelper
       }
 
       txReceipts[i] = rcp;
-      // Logger.Info($"Converted: {i}");
     }
 
     return txReceipts;
@@ -64,16 +51,8 @@ class ReceiptsHelper
   public static string CalculateRoot(TransactionReceipt[] receipts)
   {
     // Calculate the root hash of the receipts
-    // Logger.Info($"CalculateRoot: {receipts.Length}");
-
     var txReceipts = ConvertReceipts(receipts);
-    // Logger.Info($"txReceipts: {txReceipts.Length}");
-
-    // return ReceiptsRootCalculator.Instance.GetReceiptsRoot(txReceipts, new ReleaseSpec() { ValidateReceipts = false }, new Hash256("0x0")).ToString();
-
-    // var spec = new ReleaseSpec() { ValidateReceipts = false };
     var spec = HoleskySpecProvider.Instance.GetSpec(HoleskySpecProvider.Instance.TransitionActivations[1]);
-
     var _decoder = Rlp.GetStreamDecoder<TxReceipt>(RlpDecoderKey.Trie);
     return ReceiptTrie<TxReceipt>.CalculateRoot(spec, txReceipts, _decoder).ToString();
   }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -9,8 +9,10 @@ using Nethereum.JsonRpc.WebSocketStreamingClient;
 using Nethereum.RPC.Eth.Subscriptions;
 using Newtonsoft.Json;
 using System.Numerics;
+
 namespace NethermindNode.Tests.Receipts;
 
+[TestFixture]
 class ReceiptsVerification
 {
   private Web3 w3 = new Web3(NodeInfo.apiBaseUrl);

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -158,12 +158,12 @@ class ReceiptsVerification
 
   [Test]
   [Category("Receipts")]
-  public void Verify_Historical_Receipts_Near_Pivot()
+  public async Task Verify_Historical_Receipts_Near_Pivot()
   {
     Logger.Info("Verify_Historical_Receipts_Near_Pivot");
 
     var network = NodeInfo.GetNetworkType(Logger);
-    var pivotBlock = NodeInfo.GetPivotNumber(Logger);
+    var pivotBlock = await NodeInfo.GetPivotNumber(Logger);
     var head = w3.Eth.Blocks.GetBlockNumber.SendRequestAsync().Result.Value;
     var upperBound = pivotBlock + 1 * 1000 * 1000; // 1mil
     var lowerBound = pivotBlock - 1 * 1000 * 1000; // 1mil

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -108,11 +108,6 @@ class ReceiptsVerification
     var block = e.Response;
     TestContext.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
     Logger.Info($"Block: {JsonConvert.SerializeObject(block)}");
-    // var calculatedRoot = CompareHeadReceipts(block);
-    // var receiptsRoot = block.ReceiptsRoot;
-
-    // Logger.Info($"ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
-
     blocks.Enqueue(block);
   }
 
@@ -174,6 +169,7 @@ class ReceiptsVerification
         var calculatedRoot = CompareHeadReceipts(block);
         var receiptsRoot = block.ReceiptsRoot;
         Logger.Info($"ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
+        Assert.That(calculatedRoot, Is.EqualTo(receiptsRoot));
       }
       // if (sw.Elapsed.Seconds % 10 == 0)
       // {

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -113,7 +113,7 @@ class ReceiptsVerification
 
     // Logger.Info($"ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
 
-    blocks.Append(block);
+    blocks.Enqueue(block);
   }
 
 

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -204,7 +204,7 @@ class ReceiptsVerification
 
       var calculatedRoot = CompareHeadReceipts(block);
       var receiptsRoot = block.ReceiptsRoot;
-      Logger.Info($"[{block.Number}] ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
+      Logger.Info($"[{block.Number}] [{block.BlockHash}] ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
       Assert.That(calculatedRoot, Is.EqualTo(receiptsRoot));
       count++;
 

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -13,9 +13,7 @@ namespace NethermindNode.Tests.Receipts;
 
 class ReceiptsVerification
 {
-  private const string RpcAddress = "http://localhost:8545";
-  private const string WsAddress = "ws://localhost:8545";
-  private Web3 w3 = new Web3(RpcAddress);
+  private Web3 w3 = new Web3(NodeInfo.apiBaseUrl);
   private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger(TestContext.CurrentContext.Test.Name);
   public Queue<Block> blocks = new Queue<Block>();
 
@@ -25,7 +23,7 @@ class ReceiptsVerification
   {
     var testRunTime = 2 * 60 * 1000; // 10 minutes
 
-    var client = new StreamingWebSocketClient(WsAddress);
+    var client = new StreamingWebSocketClient(NodeInfo.wsBaseUrl);
     var subscription = new EthNewBlockHeadersSubscription(client);
 
     // attach our handler for new block header data

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -1,0 +1,129 @@
+using NethermindNode.Core.Helpers;
+using Nethereum.Web3;
+using Nethereum.RPC.Eth.DTOs;
+using Nethereum.Hex.HexTypes;
+using Nethereum.JsonRpc.Client;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using NethermindNode.Core.Helpers;
+using NUnit.Framework.Internal;
+
+using Nethereum.JsonRpc.WebSocketClient;
+using Nethereum.Web3;
+
+using Nethereum.ABI.FunctionEncoding.Attributes;
+using Nethereum.Contracts;
+using Nethereum.JsonRpc.Client.Streaming;
+using Nethereum.JsonRpc.WebSocketStreamingClient;
+using Nethereum.RPC.Reactive.Eth.Subscriptions;
+using Nethereum.RPC.Eth.Subscriptions;
+using Newtonsoft.Json;
+using System;
+using System.Numerics;
+using System.Threading.Tasks;
+namespace NethermindNode.Tests.Receipts;
+
+class ReceiptsVerification
+{
+  private const string RpcAddress = "http://localhost:8545";
+  private const string WsAddress = "ws://localhost:8545";
+
+  private Web3 w3 = new Web3(RpcAddress);
+
+
+  private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger(TestContext.CurrentContext.Test.Name);
+
+  public Queue<Block> blocks = new Queue<Block>();
+
+
+  [Test]
+  [Category("Receipts")]
+  public void ShouldVerifyHeadReceipts()
+  {
+    Logger.Info($"***Starting test: ShouldVerifyHeadReceipts ***");
+    var w3 = new Web3(RpcAddress);
+    var blockNumber = w3.Eth.Blocks.GetBlockNumber.SendRequestAsync().Result.Value;
+    Console.WriteLine($"Current block number: {blockNumber}");
+  }
+
+
+  // 1. Head receipts verification
+  private void CompareHeadReceipts(Block block)
+  {
+    var receiptsRoot = block.ReceiptsRoot;
+    var hash = block.BlockHash;
+    var number = block.Number.Value;
+
+    var receipts = w3.Eth.Blocks.GetBlockReceiptsByNumber.SendRequestAsync(new HexBigInteger(number)).Result;
+
+    ReceiptsHelper.CalculateRoot(receipts);
+
+
+    /*
+    1. On synced node subscribe to new blocks using eth_subscribe with newHeads topic
+    2. Whenever notification from subscription is received we should:
+        1. Get ReceiptsRoot from new block
+        2. Get new block hash
+        3. Use block hash and call **eth_getBlockReceipts** and calculate hash of all receipts (use Nethermind method for that or craft a new one to have a separate implementation).
+        4. Compare Hashes from point i and iii.
+    3. Thing to consider: we are “losing receipts” from time to time in unknown way so maybe such tool should not only check once after subscription notification but “recheck” also after some time (maybe after pruning interval?) to make sure receipts are properly flushed to DB
+    */
+
+  }
+
+  public void SubscriptionHandler(object sender, StreamingEventArgs<Block> e)
+  {
+    var utcTimestamp = DateTimeOffset.FromUnixTimeSeconds((long)e.Response.Timestamp.Value);
+    Console.WriteLine($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
+    var block = e.Response;
+    Console.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
+    CompareHeadReceipts(block);
+  }
+
+
+
+  [Test]
+  [Category("Receipts")]
+  public async Task NewBlockHeader_With_Subscription()
+  {
+    var client = new StreamingWebSocketClient(WsAddress);
+    // create a subscription 
+    // it won't do anything just yet though
+    var subscription = new EthNewBlockHeadersSubscription(client);
+
+    // attach our handler for new block header data
+    subscription.SubscriptionDataResponse += SubscriptionHandler;
+
+    bool subscribed = true;
+
+    // handle unsubscription
+    // optional - but may be important depending on your use case
+    subscription.UnsubscribeResponse += (object sender, StreamingEventArgs<bool> success) =>
+    {
+      subscribed = false;
+      Console.WriteLine($"Unsubscribed: {success.Response}");
+    };
+
+    // open the web socket connection
+    await client.StartAsync();
+
+    // subscribe to new block headers
+    // blocks will be received on another thread
+    // therefore this doesn't block the current thread
+    await subscription.SubscribeAsync();
+
+    //allow some time before we close the connection and end the subscription
+    // await Task.Delay(TimeSpan.FromMinutes(1));
+
+    // // run for a minute before unsubscribing
+    // await Task.Delay(TimeSpan.FromMinutes(1));
+
+    // // unsubscribe
+    // await subscription.UnsubscribeAsync();
+
+    //allow time to unsubscribe
+    while (subscribed) await Task.Delay(TimeSpan.FromSeconds(1));
+
+    // the connection closing will end the subscription
+  }
+}

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -159,7 +159,7 @@ class ReceiptsVerification
       }
       if (sw.ElapsedMilliseconds > testRunTime)
       {
-        subscription.UnsubscribeAsync().Wait();
+        await subscription.UnsubscribeAsync();
         break;
       }
     }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -104,13 +104,12 @@ class ReceiptsVerification
   {
     var utcTimestamp = DateTimeOffset.FromUnixTimeSeconds((long)e.Response.Timestamp.Value);
     TestContext.WriteLine($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
-    Logger.Info($"\n\nNew Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
+    Logger.Info($"\n\n\n\nNew Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
     var block = e.Response;
-    TestContext.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
-    Logger.Info($"Block: {JsonConvert.SerializeObject(block)}");
+    // TestContext.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
+    // Logger.Info($"Block: {JsonConvert.SerializeObject(block)}");
     blocks.Enqueue(block);
   }
-
 
   [Test]
   [Category("Receipts")]
@@ -144,14 +143,6 @@ class ReceiptsVerification
     // therefore this doesn't block the current thread
     await subscription.SubscribeAsync();
 
-    //allow some time before we close the connection and end the subscription
-    // await Task.Delay(TimeSpan.FromMinutes(1));
-
-    // // run for a minute before unsubscribing
-    // await Task.Delay(TimeSpan.FromMinutes(1));
-
-    // // unsubscribe
-    // await subscription.UnsubscribeAsync();
 
     TestContext.Write("Waiting for new blocks: ");
     Logger.Info("Waiting for new blocks: ");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -80,7 +80,7 @@ class ReceiptsVerification
     var w3 = new Web3(RpcAddress);
 
     var receipts = w3.Eth.Blocks.GetBlockReceiptsByNumber.SendRequestAsync(new HexBigInteger(number)).Result;
-    Logger.Info($"Receipts: {JsonConvert.SerializeObject(receipts)}");
+    Logger.Info($"Receipts count: {receipts.Length}");
 
 
     return ReceiptsHelper.CalculateRoot(receipts);

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -62,6 +62,7 @@ class ReceiptsVerification
   public void ShouldVerifyHeadReceipts()
   {
     TestContext.WriteLine("ShouldVerifyHeadReceipts");
+    Logger.Info("ShouldVerifyHeadReceipts");
 
     Logger.Info($"***Starting test: ShouldVerifyHeadReceipts ***");
     var w3 = new Web3(RpcAddress);
@@ -99,8 +100,10 @@ class ReceiptsVerification
   {
     var utcTimestamp = DateTimeOffset.FromUnixTimeSeconds((long)e.Response.Timestamp.Value);
     TestContext.WriteLine($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
+    Logger.Info($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
     var block = e.Response;
     TestContext.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
+    Logger.Info($"Block: {JsonConvert.SerializeObject(block)}");
     CompareHeadReceipts(block);
   }
 
@@ -126,6 +129,7 @@ class ReceiptsVerification
     {
       subscribed = false;
       TestContext.WriteLine($"Unsubscribed: {success.Response}");
+      Logger.Info($"Unsubscribed: {success.Response}");
     };
 
     // open the web socket connection
@@ -146,6 +150,7 @@ class ReceiptsVerification
     // await subscription.UnsubscribeAsync();
 
     TestContext.Write("Waiting for new blocks: ");
+    Logger.Info("Waiting for new blocks: ");
 
     var sw = new Stopwatch();
     sw.Start();
@@ -154,6 +159,7 @@ class ReceiptsVerification
     {
       Task.Delay(1000).Wait();
       TestContext.Write(".");
+      Logger.Info(".");
       if (sw.Elapsed.Seconds > 120)
       {
         break;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -41,10 +41,10 @@ class ReceiptsVerification
   {
     Console.WriteLine("ShouldVerifyHeadReceipts");
 
-    // Logger.Info($"***Starting test: ShouldVerifyHeadReceipts ***");
-    // var w3 = new Web3(RpcAddress);
-    // var blockNumber = w3.Eth.Blocks.GetBlockNumber.SendRequestAsync().Result.Value;
-    // Console.WriteLine($"Current block number: {blockNumber}");
+    Logger.Info($"***Starting test: ShouldVerifyHeadReceipts ***");
+    var w3 = new Web3(RpcAddress);
+    var blockNumber = w3.Eth.Blocks.GetBlockNumber.SendRequestAsync().Result.Value;
+    Console.WriteLine($"Current block number: {blockNumber}");
   }
 
 
@@ -88,43 +88,43 @@ class ReceiptsVerification
   public async Task NewBlockHeader_With_Subscription()
   {
     Console.WriteLine("NewBlockHeader_With_Subscription");
-    // var client = new StreamingWebSocketClient(WsAddress);
-    // // create a subscription 
-    // // it won't do anything just yet though
-    // var subscription = new EthNewBlockHeadersSubscription(client);
+    var client = new StreamingWebSocketClient(WsAddress);
+    // create a subscription 
+    // it won't do anything just yet though
+    var subscription = new EthNewBlockHeadersSubscription(client);
 
-    // // attach our handler for new block header data
-    // subscription.SubscriptionDataResponse += SubscriptionHandler;
+    // attach our handler for new block header data
+    subscription.SubscriptionDataResponse += SubscriptionHandler;
 
-    // bool subscribed = true;
+    bool subscribed = true;
 
-    // // handle unsubscription
-    // // optional - but may be important depending on your use case
-    // subscription.UnsubscribeResponse += (object sender, StreamingEventArgs<bool> success) =>
-    // {
-    //   subscribed = false;
-    //   Console.WriteLine($"Unsubscribed: {success.Response}");
-    // };
+    // handle unsubscription
+    // optional - but may be important depending on your use case
+    subscription.UnsubscribeResponse += (object sender, StreamingEventArgs<bool> success) =>
+    {
+      subscribed = false;
+      Console.WriteLine($"Unsubscribed: {success.Response}");
+    };
 
-    // // open the web socket connection
-    // await client.StartAsync();
+    // open the web socket connection
+    await client.StartAsync();
 
-    // // subscribe to new block headers
-    // // blocks will be received on another thread
-    // // therefore this doesn't block the current thread
-    // await subscription.SubscribeAsync();
+    // subscribe to new block headers
+    // blocks will be received on another thread
+    // therefore this doesn't block the current thread
+    await subscription.SubscribeAsync();
 
-    // //allow some time before we close the connection and end the subscription
-    // // await Task.Delay(TimeSpan.FromMinutes(1));
+    //allow some time before we close the connection and end the subscription
+    // await Task.Delay(TimeSpan.FromMinutes(1));
 
-    // // // run for a minute before unsubscribing
-    // // await Task.Delay(TimeSpan.FromMinutes(1));
+    // // run for a minute before unsubscribing
+    // await Task.Delay(TimeSpan.FromMinutes(1));
 
-    // // // unsubscribe
-    // // await subscription.UnsubscribeAsync();
+    // // unsubscribe
+    // await subscription.UnsubscribeAsync();
 
-    // //allow time to unsubscribe
-    // while (subscribed) await Task.Delay(TimeSpan.FromSeconds(1));
+    //allow time to unsubscribe
+    while (subscribed) await Task.Delay(TimeSpan.FromSeconds(1));
 
     // the connection closing will end the subscription
   }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -80,6 +80,8 @@ class ReceiptsVerification
     var w3 = new Web3(RpcAddress);
 
     var receipts = w3.Eth.Blocks.GetBlockReceiptsByNumber.SendRequestAsync(new HexBigInteger(number)).Result;
+    Logger.Info($"Receipts: {JsonConvert.SerializeObject(receipts)}");
+
 
     return ReceiptsHelper.CalculateRoot(receipts);
 
@@ -172,7 +174,7 @@ class ReceiptsVerification
       // TestContext.Write(".");
       // TestContext.Out.Write("Message to write to log");
       // Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");
-      if (sw.ElapsedMilliseconds > 120 * 1000)
+      if (sw.ElapsedMilliseconds > 4 * 60 * 1000)
       {
         break;
       }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -193,20 +193,20 @@ class ReceiptsVerification
     //     break;
     //   }
 
-    //   // var tasks = new List<Task>();
-    //   // var i = 0;
-    //   // var max_threads = 4;
-    //   // for (i = 0; i < max_threads; i++)
-    //   // {
-    //   //   if (head - i < 0) break;
-    //   //   var blockNumber = head - i;
-    //   //   tasks.Add(Task.Run(() => ProcessBlock(blockNumber)));
-    //   // }
+    // var tasks = new List<Task>();
+    // var i = 0;
+    // var max_threads = 4;
+    // for (i = 0; i < max_threads; i++)
+    // {
+    //   if (head - i < 0) break;
+    //   var blockNumber = head - i;
+    //   tasks.Add(Task.Run(() => ProcessBlock(blockNumber)));
+    // }
 
-    //   // await Task.WhenAll(tasks);
-    //   // head -= i;
-    //   // count += i;
-    //   // block = w3.Eth.Blocks.GetBlockWithTransactionsByNumber.SendRequestAsync(new HexBigInteger(block.Number.Value - 1)).Result;
+    // await Task.WhenAll(tasks);
+    // head -= i;
+    // count += i;
+    // block = w3.Eth.Blocks.GetBlockWithTransactionsByNumber.SendRequestAsync(new HexBigInteger(block.Number.Value - 1)).Result;
     // }
 
     var upperBound = (int)head + 1;
@@ -229,7 +229,7 @@ class ReceiptsVerification
     var count = 0;
     while (true)
     {
-      var calculatedRoot = CompareHeadReceipts(block);
+      var calculatedRoot = CompareHeadReceipts(block.Number.Value);
       var receiptsRoot = block.ReceiptsRoot;
       if (count % 100 == 0)
       {

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -81,8 +81,10 @@ class ReceiptsVerification
 
     var receipts = w3.Eth.Blocks.GetBlockReceiptsByNumber.SendRequestAsync(new HexBigInteger(number)).Result;
 
-    ReceiptsHelper.CalculateRoot(receipts);
+    var calulatedRoot = ReceiptsHelper.CalculateRoot(receipts);
 
+    // assert that calculatedRoot is equal to receiptsRoot
+    Assert.That(calulatedRoot, Is.EqualTo(receiptsRoot));
 
     /*
     1. On synced node subscribe to new blocks using eth_subscribe with newHeads topic
@@ -157,9 +159,10 @@ class ReceiptsVerification
     //allow time to unsubscribe
     while (subscribed)
     {
-      Task.Delay(1000).Wait();
+      Task.Delay(100).Wait();
       TestContext.Write(".");
-      Logger.Info(".");
+      TestContext.Out.Write("Message to write to log");
+      Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");
       if (sw.Elapsed.Seconds > 120)
       {
         break;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -196,11 +196,12 @@ class ReceiptsVerification
 
       var tasks = new List<Task>();
       var i = 0;
-      var max_threads = 10;
+      var max_threads = 8;
       for (i = 0; i < max_threads; i++)
       {
         if (head - i < 0) break;
-        tasks.Add(Task.Run(() => ProcessBlock(head - i)));
+        var blockNumber = head - i;
+        tasks.Add(Task.Run(() => ProcessBlock(blockNumber)));
       }
 
       await Task.WhenAll(tasks);

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -23,7 +23,7 @@ class ReceiptsVerification
     Queue<Block> blocks = new Queue<Block>();
     var processedBlocks = new List<Block>();
 
-    var testBlocks = 128;
+    var testBlocks = 256;
 
     var client = new StreamingWebSocketClient(NodeInfo.wsBaseUrl);
     var subscription = new EthNewBlockHeadersSubscription(client);

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -83,8 +83,8 @@ class ReceiptsVerification
   }
 
 
-  [Test]
-  [Category("Receipts")]
+  // [Test]
+  // [Category("Receipts")]
   public async Task NewBlockHeader_With_Subscription()
   {
     Console.WriteLine("NewBlockHeader_With_Subscription");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -196,7 +196,7 @@ class ReceiptsVerification
 
       var tasks = new List<Task>();
       var i = 0;
-      var max_threads = 8;
+      var max_threads = 4;
       for (i = 0; i < max_threads; i++)
       {
         if (head - i < 0) break;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -162,15 +162,6 @@ class ReceiptsVerification
         Logger.Info($"ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
         Assert.That(calculatedRoot, Is.EqualTo(receiptsRoot));
       }
-      // if (sw.Elapsed.Seconds % 10 == 0)
-      // {
-      //   TestContext.WriteLine(".");
-      //   Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");
-      // }
-      // Task.Delay(100).Wait();
-      // TestContext.Write(".");
-      // TestContext.Out.Write("Message to write to log");
-      // Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");
       if (sw.ElapsedMilliseconds > 10 * 60 * 1000)
       {
         break;

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -35,16 +35,16 @@ class ReceiptsVerification
   // public Queue<Block> blocks = new Queue<Block>();
 
 
-  [Test]
-  [Category("Receipts")]
+  // [Test]
+  // [Category("Receipts")]
   public void ShouldVerifyHeadReceipts()
   {
-    Console.WriteLine("ShouldVerifyHeadReceipts");
+    TestContext.WriteLine("ShouldVerifyHeadReceipts");
 
     Logger.Info($"***Starting test: ShouldVerifyHeadReceipts ***");
     var w3 = new Web3(RpcAddress);
     var blockNumber = w3.Eth.Blocks.GetBlockNumber.SendRequestAsync().Result.Value;
-    Console.WriteLine($"Current block number: {blockNumber}");
+    TestContext.WriteLine($"Current block number: {blockNumber}");
   }
 
 
@@ -76,18 +76,18 @@ class ReceiptsVerification
   public void SubscriptionHandler(object sender, StreamingEventArgs<Block> e)
   {
     var utcTimestamp = DateTimeOffset.FromUnixTimeSeconds((long)e.Response.Timestamp.Value);
-    Console.WriteLine($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
+    TestContext.WriteLine($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
     var block = e.Response;
-    Console.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
+    TestContext.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
     CompareHeadReceipts(block);
   }
 
 
-  // [Test]
-  // [Category("Receipts")]
+  [Test]
+  [Category("Receipts")]
   public async Task NewBlockHeader_With_Subscription()
   {
-    Console.WriteLine("NewBlockHeader_With_Subscription");
+    TestContext.WriteLine("NewBlockHeader_With_Subscription");
     var client = new StreamingWebSocketClient(WsAddress);
     // create a subscription 
     // it won't do anything just yet though
@@ -103,7 +103,7 @@ class ReceiptsVerification
     subscription.UnsubscribeResponse += (object sender, StreamingEventArgs<bool> success) =>
     {
       subscribed = false;
-      Console.WriteLine($"Unsubscribed: {success.Response}");
+      TestContext.WriteLine($"Unsubscribed: {success.Response}");
     };
 
     // open the web socket connection

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -163,11 +163,17 @@ class ReceiptsVerification
     var upperBound = (int)head + 1;
     var lowerBound = 0; // genesis
 
-    Parallel.For(lowerBound, upperBound, i =>
+    ParallelOptions parallelOptions = new ParallelOptions
+    {
+      // Set the maximum number of concurrent operations
+      MaxDegreeOfParallelism = 16
+    };
+
+
+    Parallel.For(lowerBound, upperBound, parallelOptions, i =>
     {
       var blockNumber = head - i;
       ProcessBlock(blockNumber);
-      Thread.Sleep(1000);
     });
   }
 

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -163,7 +163,7 @@ class ReceiptsVerification
     //allow time to unsubscribe
     while (subscribed)
     {
-      if (sw.ElapsedMilliseconds % 1000 == 0)
+      if (sw.Elapsed.Seconds % 10 == 0)
       {
         TestContext.WriteLine(".");
         Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -104,12 +104,11 @@ class ReceiptsVerification
     blocks.Enqueue(block);
   }
 
-  [Test]
-  [Category("Receipts")]
+  // [Test]
+  // [Category("Receipts")]
   public async Task Verify_New_Receipts()
   {
     var testRunTime = 2 * 60 * 1000; // 10 minutes
-
 
     var client = new StreamingWebSocketClient(WsAddress);
     // create a subscription 
@@ -160,6 +159,8 @@ class ReceiptsVerification
       if (sw.ElapsedMilliseconds > testRunTime)
       {
         await subscription.UnsubscribeAsync();
+        subscribed = false;
+        await client.StopAsync();
         break;
       }
     }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -116,7 +116,7 @@ class ReceiptsVerification
 
   [Test]
   [Category("Receipts")]
-  public void NewBlockHeader_With_Subscription()
+  public async Task NewBlockHeader_With_Subscription()
   {
     TestContext.WriteLine("NewBlockHeader_With_Subscription");
     var client = new StreamingWebSocketClient(WsAddress);
@@ -139,12 +139,12 @@ class ReceiptsVerification
     };
 
     // open the web socket connection
-    client.StartAsync().Wait();
+    await client.StartAsync();
 
     // subscribe to new block headers
     // blocks will be received on another thread
     // therefore this doesn't block the current thread
-    subscription.SubscribeAsync().Wait();
+    await subscription.SubscribeAsync();
 
     //allow some time before we close the connection and end the subscription
     // await Task.Delay(TimeSpan.FromMinutes(1));

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -28,22 +28,23 @@ class ReceiptsVerification
   private const string RpcAddress = "http://localhost:8545";
   private const string WsAddress = "ws://localhost:8545";
 
-  private Web3 w3 = new Web3(RpcAddress);
-
+  // private Web3 w3 = new Web3(RpcAddress);
 
   private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger(TestContext.CurrentContext.Test.Name);
 
-  public Queue<Block> blocks = new Queue<Block>();
+  // public Queue<Block> blocks = new Queue<Block>();
 
 
   [Test]
   [Category("Receipts")]
   public void ShouldVerifyHeadReceipts()
   {
-    Logger.Info($"***Starting test: ShouldVerifyHeadReceipts ***");
-    var w3 = new Web3(RpcAddress);
-    var blockNumber = w3.Eth.Blocks.GetBlockNumber.SendRequestAsync().Result.Value;
-    Console.WriteLine($"Current block number: {blockNumber}");
+    Console.WriteLine("ShouldVerifyHeadReceipts");
+
+    // Logger.Info($"***Starting test: ShouldVerifyHeadReceipts ***");
+    // var w3 = new Web3(RpcAddress);
+    // var blockNumber = w3.Eth.Blocks.GetBlockNumber.SendRequestAsync().Result.Value;
+    // Console.WriteLine($"Current block number: {blockNumber}");
   }
 
 
@@ -53,6 +54,7 @@ class ReceiptsVerification
     var receiptsRoot = block.ReceiptsRoot;
     var hash = block.BlockHash;
     var number = block.Number.Value;
+    var w3 = new Web3(RpcAddress);
 
     var receipts = w3.Eth.Blocks.GetBlockReceiptsByNumber.SendRequestAsync(new HexBigInteger(number)).Result;
 
@@ -81,48 +83,48 @@ class ReceiptsVerification
   }
 
 
-
   [Test]
   [Category("Receipts")]
   public async Task NewBlockHeader_With_Subscription()
   {
-    var client = new StreamingWebSocketClient(WsAddress);
-    // create a subscription 
-    // it won't do anything just yet though
-    var subscription = new EthNewBlockHeadersSubscription(client);
+    Console.WriteLine("NewBlockHeader_With_Subscription");
+    // var client = new StreamingWebSocketClient(WsAddress);
+    // // create a subscription 
+    // // it won't do anything just yet though
+    // var subscription = new EthNewBlockHeadersSubscription(client);
 
-    // attach our handler for new block header data
-    subscription.SubscriptionDataResponse += SubscriptionHandler;
+    // // attach our handler for new block header data
+    // subscription.SubscriptionDataResponse += SubscriptionHandler;
 
-    bool subscribed = true;
+    // bool subscribed = true;
 
-    // handle unsubscription
-    // optional - but may be important depending on your use case
-    subscription.UnsubscribeResponse += (object sender, StreamingEventArgs<bool> success) =>
-    {
-      subscribed = false;
-      Console.WriteLine($"Unsubscribed: {success.Response}");
-    };
+    // // handle unsubscription
+    // // optional - but may be important depending on your use case
+    // subscription.UnsubscribeResponse += (object sender, StreamingEventArgs<bool> success) =>
+    // {
+    //   subscribed = false;
+    //   Console.WriteLine($"Unsubscribed: {success.Response}");
+    // };
 
-    // open the web socket connection
-    await client.StartAsync();
+    // // open the web socket connection
+    // await client.StartAsync();
 
-    // subscribe to new block headers
-    // blocks will be received on another thread
-    // therefore this doesn't block the current thread
-    await subscription.SubscribeAsync();
+    // // subscribe to new block headers
+    // // blocks will be received on another thread
+    // // therefore this doesn't block the current thread
+    // await subscription.SubscribeAsync();
 
-    //allow some time before we close the connection and end the subscription
-    // await Task.Delay(TimeSpan.FromMinutes(1));
+    // //allow some time before we close the connection and end the subscription
+    // // await Task.Delay(TimeSpan.FromMinutes(1));
 
-    // // run for a minute before unsubscribing
-    // await Task.Delay(TimeSpan.FromMinutes(1));
+    // // // run for a minute before unsubscribing
+    // // await Task.Delay(TimeSpan.FromMinutes(1));
 
-    // // unsubscribe
-    // await subscription.UnsubscribeAsync();
+    // // // unsubscribe
+    // // await subscription.UnsubscribeAsync();
 
-    //allow time to unsubscribe
-    while (subscribed) await Task.Delay(TimeSpan.FromSeconds(1));
+    // //allow time to unsubscribe
+    // while (subscribed) await Task.Delay(TimeSpan.FromSeconds(1));
 
     // the connection closing will end the subscription
   }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -54,7 +54,7 @@ class ReceiptsVerification
 
   private static readonly NLog.Logger Logger = NLog.LogManager.GetLogger(TestContext.CurrentContext.Test.Name);
 
-  // public Queue<Block> blocks = new Queue<Block>();
+  public Queue<Block> blocks = new Queue<Block>();
 
 
   // [Test]
@@ -104,15 +104,16 @@ class ReceiptsVerification
   {
     var utcTimestamp = DateTimeOffset.FromUnixTimeSeconds((long)e.Response.Timestamp.Value);
     TestContext.WriteLine($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
-    Logger.Info($"New Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
+    Logger.Info($"\n\nNew Block: Number: {e.Response.Number.Value}, Timestamp: {JsonConvert.SerializeObject(utcTimestamp)}");
     var block = e.Response;
     TestContext.WriteLine($"Block: {JsonConvert.SerializeObject(block)}");
     Logger.Info($"Block: {JsonConvert.SerializeObject(block)}");
-    var calculatedRoot = CompareHeadReceipts(block);
-    var receiptsRoot = block.ReceiptsRoot;
+    // var calculatedRoot = CompareHeadReceipts(block);
+    // var receiptsRoot = block.ReceiptsRoot;
 
-    Logger.Info($"ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
+    // Logger.Info($"ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
 
+    blocks.Append(block);
   }
 
 
@@ -165,6 +166,15 @@ class ReceiptsVerification
     //allow time to unsubscribe
     while (subscribed)
     {
+      if (blocks.Count > 0)
+      {
+        var block = blocks.Dequeue();
+        Logger.Info($"Processing: {block.BlockHash}");
+
+        var calculatedRoot = CompareHeadReceipts(block);
+        var receiptsRoot = block.ReceiptsRoot;
+        Logger.Info($"ReceiptsRoot: {receiptsRoot} CalculatedRoot: {calculatedRoot} {calculatedRoot == receiptsRoot}");
+      }
       // if (sw.Elapsed.Seconds % 10 == 0)
       // {
       //   TestContext.WriteLine(".");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -163,11 +163,11 @@ class ReceiptsVerification
     //allow time to unsubscribe
     while (subscribed)
     {
-      if (sw.Elapsed.Seconds % 10 == 0)
-      {
-        TestContext.WriteLine(".");
-        Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");
-      }
+      // if (sw.Elapsed.Seconds % 10 == 0)
+      // {
+      //   TestContext.WriteLine(".");
+      //   Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");
+      // }
       // Task.Delay(100).Wait();
       // TestContext.Write(".");
       // TestContext.Out.Write("Message to write to log");

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -171,7 +171,7 @@ class ReceiptsVerification
       // TestContext.Write(".");
       // TestContext.Out.Write("Message to write to log");
       // Logger.Info($". ({sw.Elapsed.Seconds}s) {subscription.SubscriptionState}");
-      if (sw.ElapsedMilliseconds > 4 * 60 * 1000)
+      if (sw.ElapsedMilliseconds > 10 * 60 * 1000)
       {
         break;
       }

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -147,11 +147,17 @@ class ReceiptsVerification
 
     TestContext.Write("Waiting for new blocks: ");
 
+    var sw = new Stopwatch();
+    sw.Start();
     //allow time to unsubscribe
     while (subscribed)
     {
       Task.Delay(1000).Wait();
       TestContext.Write(".");
+      if (sw.Elapsed.Seconds > 120)
+      {
+        break;
+      }
     }
 
     // the connection closing will end the subscription

--- a/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
+++ b/NethermindNode.Tests/Tests/Receipts/ReceiptsVerification.cs
@@ -23,6 +23,28 @@ using System.Numerics;
 using System.Threading.Tasks;
 namespace NethermindNode.Tests.Receipts;
 
+public static class DBG
+{
+  public static Task WriteLineA(string message)
+  {
+    return Task.Run(() => Console.WriteLine(message));
+  }
+
+  public static Task WriteA(string message)
+  {
+    return Task.Run(() => Console.Write(message));
+  }
+  public static void WriteLine(string message)
+  {
+    Console.WriteLine(message);
+  }
+
+  public static void Write(string message)
+  {
+    Console.Write(message);
+  }
+}
+
 class ReceiptsVerification
 {
   private const string RpcAddress = "http://localhost:8545";
@@ -85,7 +107,7 @@ class ReceiptsVerification
 
   [Test]
   [Category("Receipts")]
-  public async Task NewBlockHeader_With_Subscription()
+  public void NewBlockHeader_With_Subscription()
   {
     TestContext.WriteLine("NewBlockHeader_With_Subscription");
     var client = new StreamingWebSocketClient(WsAddress);
@@ -107,12 +129,12 @@ class ReceiptsVerification
     };
 
     // open the web socket connection
-    await client.StartAsync();
+    client.StartAsync().Wait();
 
     // subscribe to new block headers
     // blocks will be received on another thread
     // therefore this doesn't block the current thread
-    await subscription.SubscribeAsync();
+    subscription.SubscribeAsync().Wait();
 
     //allow some time before we close the connection and end the subscription
     // await Task.Delay(TimeSpan.FromMinutes(1));
@@ -123,8 +145,14 @@ class ReceiptsVerification
     // // unsubscribe
     // await subscription.UnsubscribeAsync();
 
+    TestContext.Write("Waiting for new blocks: ");
+
     //allow time to unsubscribe
-    while (subscribed) await Task.Delay(TimeSpan.FromSeconds(1));
+    while (subscribed)
+    {
+      Task.Delay(1000).Wait();
+      TestContext.Write(".");
+    }
 
     // the connection closing will end the subscription
   }


### PR DESCRIPTION
This PR adds a few tests that are designed to test receipts integrity in the node:

**Tests:**
- `[Category("ReceiptsNew")]` - Subscribes to block head, and verifies Receipts root matches our calculation 
- `[Category("ReceiptsToGenesis")]` - Starts from head, and goes back to genesis 
- `[Category("ReceiptsNearPivot")]` - Pulls PivotNumber from Nethermind node, and checks [-500k; 500k] around the pivot block
- `[Category("ReceiptsNearAncientBarrier")]` - Same as above but for ReceiptsAncientBarrier 

**NOTE:**
Some of the tests are using debug RPC endpoint(which rely on node's config/state), so it is required to enable Debug RPC module.

Also, for the receipts root calculation, I've setup nethermind repo as a submodule for the code reuse etc.  
