### PR TITLE
Allowlist eth/70 'Receipt count mismatch' in fuzzing log scan

### DIFF
--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -293,6 +293,7 @@ public static class NodeInfo
         "ObjectDisposedException",      // Timer disposal race condition
         "DISCONNECT",                   // NetworkDiag peer disconnect traces (RlpException, etc.)
         "Error in communication with",  // NetworkDiag peer communication errors
+        "Receipt count mismatch",       // eth/70 receipts mismatch when remote peer briefly lacks receipts (NethermindEth/nethermind#11752)
     };
 
     private static bool IsIgnoredException(string logLine)


### PR DESCRIPTION
## Summary

Adds `"Receipt count mismatch"` to `IgnoredExceptionPatterns` in `NodeInfo.cs` so the fuzzing pipeline's docker-log keyword grep doesn't fail tests on the benign eth/70 receipts mismatch.

## Context

`SubprotocolException: Receipt count mismatch with block transactions count` is thrown at `Eth70ProtocolHandler.cs:625` (`ValidateReceiptCount`) when a remote peer serves an empty receipts array for a block whose header it has but whose receipts haven't warmed yet. The exception message contains `Exception`, which the docker-log keyword grep at `VerifyLogsForUndesiredEntries` matches → the fuzzing test fails.

NethermindEth/nethermind#11752 fixes the **local** serving side (won't emit `[]` for unknown blocks anymore), but we still observe the exception coming from older peers across the network — the cross-version interop window is open while peers upgrade.

Per review feedback on PR NethermindEth/nethermind#11754: *"I'd log this as a problem, but ignore in the fuzzing pipeline"*. The exception remains visible at source (Nethermind keeps logging it), we just stop treating it as a fuzz-pipeline regression.

## Test plan
- [ ] CI passes (no fuzzing tests broken by the addition)
- [ ] Confirm the substring is narrow enough — only matches `Receipt count mismatch with block transactions count`, not the deliberately stricter `Receipt count exceeds block transactions count` at line 620 (which catches actual malicious overrun)