### PR TITLE
Allowlist Hello-capability L8 rejection in fuzzing log scan

### DIFF
--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -293,6 +293,7 @@ public static class NodeInfo
         "ObjectDisposedException",      // Timer disposal race condition
         "DISCONNECT",                   // NetworkDiag peer disconnect traces (RlpException, etc.)
         "Error in communication with",  // NetworkDiag peer communication errors
+        "over limit 8 or",              // RlpLimitException at HelloMessageSerializer when a peer advertises a capability protocol code >8 bytes — strict spec rejection is intended behavior (NethermindEth/nethermind#11751 closed without merge)
     };
 
     private static bool IsIgnoredException(string logLine)


### PR DESCRIPTION
## Summary

Adds the substring \`"over limit 8 or"\` to \`IgnoredExceptionPatterns\` so the fuzzing pipeline's docker-log keyword grep stops failing tests when \`HelloMessageSerializer\` rejects peers advertising over-8-byte capability protocol codes.

## Context

When a remote peer's Hello capabilities include a protocol code whose byte span exceeds devp2p's 8-byte spec limit, \`HelloMessageSerializer.Deserialize\` throws:

\`\`\`
Nethermind.Serialization.Rlp.RlpLimitException: Collection count of 13 is over limit 8 or 81 bytes left
\`\`\`

This is **intended behavior** — strict devp2p spec compliance. NethermindEth/nethermind#11753 ("Keep devp2p 8-byte capability limit; log rejected bytes for diagnosis") was **closed without merge** with reviewer comment "works as it should be"; the rejection itself is correct.

But the rendered exception line contains "Exception", so \`VerifyLogsForUndesiredEntries\` matches it and fails the fuzz test. We confirmed (via a diagnostic instrumented build run through \`receive-push-notification.yml\`) the over-spec codes come from legitimate ecosystem clients — \`bzz-retrieve\` (Swarm), \`parallax-snap\`/\`parallax-disc\` (Parallax), \`chainfusion\` (Geth fork) — and there's nothing to "fix" on our side.

Per review feedback: *"I'd log this as a problem, but ignore in the fuzzing pipeline."*

## Why \`"over limit 8 or"\`

- Anchored to the standard \`RlpLimitException\` message format (\`"Collection count of N is over limit X or M bytes left"\`)
- The \`8\` narrows it to L8 violations only — \`RlpLimit.L8\` appears in just two sites on master:
  1. \`HelloMessageSerializer.cs:74\` (the case we want to ignore)
  2. \`NetworkNodeDecoder.cs:23\` (ENR port decode — fires only on corrupt ENR, exceedingly rare)
- Won't match other RlpLimit violations (e.g. the 1.37.0 BlobTxDecoder regression was \`over limit 16384\`, kept catchable)

## Test plan
- [ ] CI green (existing tests not affected by the addition)
- [ ] Verify next fuzzing run that previously failed on Hello-cap rejection now passes