### PR TITLE
Allowlist malformed peer-message deserialize in fuzzing log scan

### DIFF
--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -295,6 +295,7 @@ public static class NodeInfo
         "DISCONNECT",                      // NetworkDiag peer disconnect traces (RlpException, etc.)
         "Error in communication with",     // NetworkDiag peer communication errors
         "over limit 8 or",                 // RlpLimitException at HelloMessageSerializer when a peer advertises a capability protocol code >8 bytes — strict spec rejection is intended behavior (NethermindEth/nethermind#11751 closed without merge)
+        "Failed to deserialize message",   // ProtocolHandlerBase: a peer that negotiated eth/69+ sent a malformed/old-format Status (or Disconnect) message — Nethermind's eth/69 decoder hits a scalar where a 32-byte hash is expected and throws DecodeKeccakRlpException/RlpException. These are non-conformant or foreign-network peers (e.g. energi3, bor, besu-dev); the node correctly disconnects them and syncs fine. Capability negotiation only agrees versions the peer advertised, so this is benign peer noise, not a node defect.
     };
 
     private static bool IsIgnoredException(string logLine)


### PR DESCRIPTION
## Problem

The fuzzing log scan (`NodeInfo.VerifyLogsForUndesiredEntries`) greps docker logs for the literal token `Exception` **regardless of log level**, then fails the run on any hit not in `IgnoredExceptionPatterns`.

`ProtocolHandlerBase` logs the following at **DEBUG** when a peer that negotiated eth/69+ sends a malformed or old-format Status/Disconnect message:

```
Network.P2P.ProtocolHandlers.ProtocolHandlerBase | Failed to deserialize message StatusMessage69 on session [...],
  with exception ...DecodeKeccakRlpException: Unexpected prefix of 132 when decoding Hash256 at position 6 ...
```

eth/69 Status is `[version, networkId, genesisHash:B32, forkId, ...]` whereas eth/63-68 Status is `[version, networkId, totalDifficulty:scalar, ...]`. A peer that advertised eth/69+ but sends an old-format (TD-bearing) status puts a multi-byte scalar exactly where the 32-byte genesis hash is expected, so `DecodeKeccak()` throws.

Capability negotiation (`P2PProtocolHandler.HandleHello`) only agrees on versions the peer **advertised** (intersection with our supported set, highest common). The node correctly disconnects these peers and syncs fine — observed on chiado/mainnet fuzz nodes (post-merge-smoke-tests run 26614371271, job `FuzzCL`) from non-conformant / foreign-network peers (`energi3`, `bor`, `besu-dev`). This is benign peer noise, **not a node defect** (investigated against the client source; no regression — the eth/69 status decoder is unchanged since eth/69 landed in NethermindEth/nethermind#7052).

## Fix

Add `"Failed to deserialize message"` to `IgnoredExceptionPatterns`.

- The sibling `"Error in communication with"` entry already covers the `ZeroNettyP2PHandler` / `ProtocolsManager` / `Session` variants of the same disconnect; the `ProtocolHandlerBase` (`Failed to deserialize message`) variant was the only uncovered one.
- The string occurs **only** on `ProtocolHandlerBase`'s peer-message deserialize path in the Nethermind source, so it cannot mask real node exceptions (block/consensus/db).

## Verification

Replaying the detector logic over the FuzzCL chiado log: **1826** `Exception`-containing lines, **452** previously unmatched (440x `StatusMessage69` + 12x `DisconnectMessage`) -> **0** unmatched with this entry.

## Related

- Same class of fix as #41 (`over limit 8 or`, NethermindEth/nethermind#11751) — benign peer-message rejection that the node handles correctly; mitigated in the harness rather than the node.