### PR TITLE
Fix infinite wait in VerifyCorrectnessOfSyncStages when a sync stage is missed between polls

### DIFF
--- a/NethermindNode.Tests/Tests/SyncingNode/StagesTests.cs
+++ b/NethermindNode.Tests/Tests/SyncingNode/StagesTests.cs
@@ -63,6 +63,19 @@ public class StagesTests : BaseTest
                 {
                     TestLoggerContext.Logger.Info($"[STAGES] Waiting for {stage.Stages.ToJoinedString()}... (current: {currentStage})");
                 }
+
+                // Short-lived stages (and mode flags like FastSync, which can show up
+                // at any point or not at all) are easily missed between 1s polls. Once
+                // the node is fully synced no further stage can appear, so waiting any
+                // longer would hang the test forever \u2014 this exact hang burned 6x10h
+                // jobs per scheduled smoke run while stuck on "Waiting for SnapSync"
+                // with the node long since at WaitingForBlock.
+                if (pollCount % 30 == 0 && NodeInfo.IsFullySynced(TestLoggerContext.Logger))
+                {
+                    TestLoggerContext.Logger.Info($"[STAGES] Node became fully synced while waiting for {stage.Stages.ToJoinedString()} (current: {currentStage}). Remaining stages already completed or skipped.");
+                    Assert.Pass($"Node fully synced while waiting for {stage.Stages.ToJoinedString()} \u2014 stage was passed between polls.");
+                }
+
                 pollCount++;
                 Thread.Sleep(1000);
                 currentStage = NodeInfo.GetCurrentStage(TestLoggerContext.Logger);


### PR DESCRIPTION
## Problem

`VerifyCorrectnessOfSyncStages` waits for each sync stage **sequentially** (FastHeaders → FastSync → SnapSync → StateNodes → WaitingForBlock), polling once per second. But `FastSync` is a mode flag that appears only when a new block arrives during sync — empirically it often shows up only alongside `StateNodes`. While the test is still waiting for `FastSync`, the `SnapSync` stage completes; the test then waits forever for a stage that can never reappear:

```
[STAGES] Waiting for SnapSync... (current: WaitingForBlock)   <- x600-1400 polls, forever
```

Since the test never exits, `dotnet test` never exits, and the smoke-test job burns to its full GitHub `timeout-minutes` and ends `cancelled` — while the node is fully synced and healthy and the parallel stability test reports `[RESULT] ✓ ALL PHASES PASSED`.

This cancelled **SyncGL, SyncGLF, SyncHL, SyncHLF, SyncSP, SyncSPF at their 10h caps in both scheduled smoke runs [26923276621](https://github.com/NethermindEth/post-merge-smoke-tests/actions/runs/26923276621) and [27078568416](https://github.com/NethermindEth/post-merge-smoke-tests/actions/runs/27078568416)**, and EAPML at its 13.3h cap in run [27240246182](https://github.com/NethermindEth/post-merge-smoke-tests/actions/runs/27240246182) — ~110 wasted VM-hours per scheduled run, on healthy nodes.

## Fix

Escape hatch inside the stage-wait loop: every 30 polls, check `NodeInfo.IsFullySynced` — once the node is fully synced no further stage can ever appear, so pass the test instead of hanging. This mirrors the existing already-synced early exit at the start of the test (same rationale: a missed observation of a short-lived stage is not evidence of wrong stage order).
