### PR TITLE
fix(detector): never flag stack-trace continuation lines independently

### DIFF
--- a/NethermindNode.Core/Helpers/NodeInfo.cs
+++ b/NethermindNode.Core/Helpers/NodeInfo.cs
@@ -312,6 +312,19 @@ public static class NodeInfo
         return false;
     }
 
+    // Stack-trace continuation lines must follow their header's fate, never be judged
+    // alone: the docker-log grep for "Exception" also matches frames whose method
+    // SIGNATURE contains the word (e.g. "at CountingStreamPipeWriter.CompleteAsync(
+    // Exception exception)"), so an exception whose header is allowlisted still fails
+    // the scan on its frames (SyncSNWS, run 30865692535: "WebSocket not open (Aborted)"
+    // header ignored per allowlist, its two CompleteAsync frames flagged). The header
+    // line itself always names the exception type, so no signal is lost by skipping.
+    private static bool IsStackTraceContinuation(string logLine)
+    {
+        string trimmed = logLine.TrimStart();
+        return trimmed.StartsWith("at ") || trimmed.StartsWith("--- End of");
+    }
+
     public static bool VerifyLogsForUndesiredEntries(ref List<string> errors)
     {
         var exceptions = DockerCommands.GetDockerLogs(ConfigurationHelper.Instance["execution-container-name"], "Exception");
@@ -324,7 +337,7 @@ public static class NodeInfo
         {
             foreach (var item in exceptions)
             {
-                if (!string.IsNullOrEmpty(item) && !IsIgnoredException(item))
+                if (!string.IsNullOrEmpty(item) && !IsStackTraceContinuation(item) && !IsIgnoredException(item))
                 {
                     undesiredEntries.Add("Exception: " + item.Trim());
                     errors.Add(item);


### PR DESCRIPTION
## Problem

`VerifyLogsForUndesiredEntries` greps docker logs for `Exception` **line by line**, so stack-trace *frames* whose method signature happens to contain the word get flagged on their own — even when the exception's header line is allowlisted.

Concrete case — [SyncSNWS in the 1.39.3 release-validation run 30865692535](https://github.com/NethermindEth/post-merge-smoke-tests/actions/runs/30865692535): a routine `WebSocket not open (Aborted)` IOException during ws-client churn was correctly ignored per the existing allowlist entry (#44), but two of its frames —

```
at Nethermind.Serialization.Json.CountingStreamPipeWriter.CompleteAsync(Exception exception) in ...
```

— matched the `Exception` grep via the **parameter name in the method signature** and failed the lane. The node was healthy: the sync-stages test in the same job passed, sepolia fully synced in 3h41m.

## Fix

Skip lines that are stack-trace continuations (`at ...` / `--- End of ...`) in the exceptions scan. No signal is lost: the header line always names the exception type and is still scanned, so a real un-allowlisted exception still fails the lane via its header. This also removes the need to ever allowlist frame-shaped strings.

Sibling of the entry added in #44; complements (does not overlap) #45.