### PR TITLE
fix(stages): skip a sync stage the node is provably past (fuzz-lane residual of #43)

### DIFF
--- a/NethermindNode.Tests/Tests/SyncingNode/StagesTests.cs
+++ b/NethermindNode.Tests/Tests/SyncingNode/StagesTests.cs
@@ -76,6 +76,23 @@ public class StagesTests : BaseTest
                     Assert.Pass($"Node fully synced while waiting for {stage.Stages.ToJoinedString()} \u2014 stage was passed between polls.");
                 }
 
+                // A restart (fuzz kill / stability check) resumes from an already-populated DB, so this
+                // stage may never reappear while the node reports one that only occurs later in the
+                // pipeline (or Full block processing). The IsFullySynced escape above never fires in fuzz
+                // lanes where the node is killed mid-backfill (eth_syncing stays true), which kept burning
+                // jobs to the 10h cap on "Waiting for SnapSync" \u2014 treat the stage as missed and move on.
+                string[] currentParts = currentStage.Split(", ", StringSplitOptions.RemoveEmptyEntries);
+                bool nodeIsPastThisStage =
+                    currentParts.Contains("Full") ||
+                    currentParts.Any(part => correctOrderOfStages
+                        .Skip(correctOrderOfStages.IndexOf(stage) + 1)
+                        .Any(later => later.Stages.Any(s => s.ToString() == part)));
+                if (nodeIsPastThisStage)
+                {
+                    TestLoggerContext.Logger.Info($"[STAGES] \u26a0 {stage.Stages.ToJoinedString()} missed (current: {currentStage} occurs later in the pipeline) \u2014 passed between polls or skipped after a restart.");
+                    break;
+                }
+
                 pollCount++;
                 Thread.Sleep(1000);
                 currentStage = NodeInfo.GetCurrentStage(TestLoggerContext.Logger);


### PR DESCRIPTION
## Problem

Fuzz lanes still hang forever in `VerifyCorrectnessOfSyncStages` even with the #43 `IsFullySynced` escape, burning the job to its full GitHub `timeout-minutes` (600 min) → conclusion **`cancelled`**.

Observed in the 1.39.3 release-validation run [`30865692535`](https://github.com/NethermindEth/post-merge-smoke-tests/actions/runs/30865692535): **5 fuzz lanes cancelled simultaneously at exactly 600 min** across 3 networks and 4 CLs — FuzzCT (chiado/teku), FuzzHN (hoodi/nimbus), FuzzHLo (hoodi/lodestar), FuzzST (sepolia/teku), FuzzSP (sepolia/prysm). In every case the Nethermind EL was **fully synced and following chain head with zero errors** at the moment of cancellation (Loki-confirmed) — e.g. FuzzHN was at head block 3350440 with `debug_getSyncStage` polled **1541×**, FuzzCT at a finalized head with `eth_syncing` polled **641×**. That polling is the verification loop spinning forever. The client is healthy; the harness never exits.

## Root cause

`#43` added an `IsFullySynced` escape, but on fuzz lanes the node is killed mid-backfill and resumes from an already-populated DB. It follows the live chain head while ancient bodies/receipts are still backfilling, so `eth_syncing` stays `true` and `IsFullySynced` never returns true. Meanwhile the test is blocked waiting for a stage (e.g. `SnapSync`) that already completed and will never reappear — the node is already reporting a *later* stage. `dotnet test` never exits → job burns to the cap → `cancelled` (the classic "hung without failing" signature).

## Fix

Inside the stage-wait loop, if the node's **current** stage occurs *later* in `correctOrderOfStages` than the stage we're waiting for (or the node is in `Full` block processing), the node has provably already passed the waited-for stage → log a `⚠ … missed` marker and `break` to the next stage instead of polling forever.

Harness-only change (test code). It does **not** touch the client and does **not** hide any real failure — it only advances past a stage the node has demonstrably moved beyond, and emits an auditable log line when it does.

## Verification
- `dotnet build NethermindNode.Tests` → **0 errors**.
- Stacked on #43 (c29b89b) and #44 (57e696b); currently `main + 1 commit`.
- Directly explains all 5 cancelled fuzz lanes in run 30865692535 with zero client attribution.
